### PR TITLE
feat: restyle site to azure theme with link and chart tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,33 +4,45 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --color-primary: #1a73e8;
+  --color-primary: #1c6dd0;
   --color-on-primary: #ffffff;
-  --color-primary-container: #d3e3fd;
-  --color-background: #f3f4f6;
+  --color-primary-container: #d6e6fa;
+  --color-background: #f4f7fb;
   --color-surface: #ffffff;
-  --color-surface-variant: #f1f3f4;
-  --color-on-surface: #1f1f1f;
-  --color-on-surface-variant: #5f6368;
-  --color-outline: #dadce0;
-  --color-success: #16a34a;
-  --color-info: #2563eb;
-  --color-warning: #b8860b;
+  --color-surface-variant: #edf2f8;
+  --color-on-surface: #1a1c1e;
+  --color-on-surface-variant: #5a6470;
+  --color-outline: #cdd6e0;
+  --color-success: #1a8a4d;
+  --color-info: #1c6dd0;
+  --color-warning: #b26b00;
+  --color-link: #1c6dd0;
+  --chart-merged: #1a8a4d;
+  --chart-in-review: #1c6dd0;
+  --chart-draft: #8a93a3;
+  --chart-unknown: #b26b00;
+  --chart-bar: #1c6dd0;
 }
 
 .dark {
-  --color-primary: #8ab4f8;
-  --color-on-primary: #062e6f;
-  --color-primary-container: #0842a0;
-  --color-background: #131314;
-  --color-surface: #1e1f20;
-  --color-surface-variant: #2d2e30;
-  --color-on-surface: #e3e3e3;
-  --color-on-surface-variant: #9aa0a6;
-  --color-outline: #444746;
+  --color-primary: #5fa8f5;
+  --color-on-primary: #06294d;
+  --color-primary-container: #0b3a6b;
+  --color-background: #0f1620;
+  --color-surface: #18212e;
+  --color-surface-variant: #232e3d;
+  --color-on-surface: #e3e8ef;
+  --color-on-surface-variant: #9aa6b5;
+  --color-outline: #34404f;
   --color-success: #4ade80;
-  --color-info: #8ab4f8;
+  --color-info: #5fa8f5;
   --color-warning: #fbbf24;
+  --color-link: #7bbaf7;
+  --chart-merged: #4ade80;
+  --chart-in-review: #5fa8f5;
+  --chart-draft: #9aa6b5;
+  --chart-unknown: #fbbf24;
+  --chart-bar: #5fa8f5;
 }
 
 @theme inline {
@@ -46,6 +58,12 @@
   --color-success: var(--color-success);
   --color-info: var(--color-info);
   --color-warning: var(--color-warning);
+  --color-link: var(--color-link);
+  --color-chart-merged: var(--chart-merged);
+  --color-chart-in-review: var(--chart-in-review);
+  --color-chart-draft: var(--chart-draft);
+  --color-chart-unknown: var(--chart-unknown);
+  --color-chart-bar: var(--chart-bar);
 }
 
 body {
@@ -73,6 +91,15 @@ a {
 .prose :where(code):not(:where([class~="not-prose"] *))::before,
 .prose :where(code):not(:where([class~="not-prose"] *))::after {
   content: none;
+}
+
+/* docs/본문 링크 색 (라이트/다크 토큰) */
+.prose :where(a):not(:where([class~="not-prose"] *)) {
+  color: var(--color-link);
+  text-decoration: none;
+}
+.prose :where(a):not(:where([class~="not-prose"] *)):hover {
+  text-decoration: underline;
 }
 
 /* 콘텐츠 넘침 방지를 위한 스타일 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,24 +25,24 @@
 }
 
 .dark {
-  --color-primary: #5fa8f5;
-  --color-on-primary: #06294d;
-  --color-primary-container: #0b3a6b;
-  --color-background: #0f1620;
-  --color-surface: #18212e;
-  --color-surface-variant: #232e3d;
-  --color-on-surface: #e3e8ef;
-  --color-on-surface-variant: #9aa6b5;
-  --color-outline: #34404f;
-  --color-success: #4ade80;
-  --color-info: #5fa8f5;
-  --color-warning: #fbbf24;
-  --color-link: #7bbaf7;
-  --chart-merged: #4ade80;
-  --chart-in-review: #5fa8f5;
-  --chart-draft: #9aa6b5;
-  --chart-unknown: #fbbf24;
-  --chart-bar: #5fa8f5;
+  --color-primary: #4f8ae0;
+  --color-on-primary: #03101f;
+  --color-primary-container: #0a2c54;
+  --color-background: #0a1020;
+  --color-surface: #0f1a2e;
+  --color-surface-variant: #18253c;
+  --color-on-surface: #dde4ee;
+  --color-on-surface-variant: #93a1b5;
+  --color-outline: #2a3851;
+  --color-success: #2f9e5b;
+  --color-info: #4f8ae0;
+  --color-warning: #d99a2b;
+  --color-link: #6fa6ee;
+  --chart-merged: #2f9e5b;
+  --chart-in-review: #3f78c8;
+  --chart-draft: #6b7686;
+  --chart-unknown: #b8862e;
+  --chart-bar: #3f78c8;
 }
 
 @theme inline {

--- a/src/components/StatsCharts.tsx
+++ b/src/components/StatsCharts.tsx
@@ -15,10 +15,10 @@ import {
 import type { Stats } from '@/lib/types';
 
 const STATUS_COLORS: Record<string, string> = {
-  merged: '#16a34a',
-  'in review': '#2563eb',
-  draft: '#9aa0a6',
-  unknown: '#b8860b',
+  merged: 'var(--chart-merged)',
+  'in review': 'var(--chart-in-review)',
+  draft: 'var(--chart-draft)',
+  unknown: 'var(--chart-unknown)',
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -28,7 +28,7 @@ const STATUS_LABELS: Record<string, string> = {
   unknown: '기타',
 };
 
-const BAR_COLOR = '#1a73e8';
+const BAR_COLOR = 'var(--chart-bar)';
 
 export default function StatsCharts({ stats }: { stats: Stats }) {
   const statusData = stats.byStatus.map((s) => ({


### PR DESCRIPTION
수정한 이슈:

## Summary

사이트 색 테마를 azure 톤으로 전면 조정. 라이트/다크 전체 팔레트를 CSS 변수 토큰으로 재구성.

- **강조색**: 라이트 azure, 다크 딥 네이비로 통일
- **본문 링크**: prose 링크 색을 전용 토큰으로 분리, 브랜드 블루 적용
- **차트**: 통계 차트 색을 CSS 변수화 → 테마 반응형(라이트↔다크 자동 전환)

## Background

- **일관성 부재**: 강조색·링크·차트 색이 토큰 없이 흩어져 테마 전환 시 부분적으로만 반영
- **다크모드 가독성**: 다크 배경/surface 톤이 충분히 깊지 않아 대비 약함
- **차트 고정색**: 통계 대시보드 차트가 고정 색이라 다크모드에서 부자연스러움

## Changes

- **라이트 팔레트**: 강조색 azure(#1c6dd0) 기준 재정렬
- **다크 팔레트**: 강조색 딥 네이비(#4f8ae0), 배경/surface도 딥 네이비로 낮춤
- **링크 토큰**: docs·패치 상세 본문(prose) 링크에 `--color-link`(브랜드 블루) 분리 적용
- **차트 토큰화**: 통계 차트 색을 CSS 변수로 전환, 다크에서 어두운 톤으로 자동 조정
- **범위**: 컴포넌트 구조 변경 없음 — globals.css 토큰값 + StatsCharts 색 참조 방식만 변경

## Test

- [x] 단위 테스트 42개 통과
- [x] 정적 빌드 68페이지 성공
- [x] 라이트/다크 전환 시 강조색·링크·차트 색 정상 반영 확인
