### PR TITLE
Default year filters to 2026 across pages

### DIFF
--- a/__tests__/lib/years.test.ts
+++ b/__tests__/lib/years.test.ts
@@ -2,7 +2,6 @@ import {
   getYear,
   getAvailableYears,
   getDataYears,
-  resolveInitialYear,
   filterByYear,
   DEFAULT_YEAR,
 } from '@/lib/years';
@@ -25,12 +24,6 @@ test('getDataYears는 데이터에 실제 존재하는 연도만 내림차순으
   expect(getDataYears([{ date: '2025-05-08' }, { date: '2025-06-01' }])).toEqual(['2025']);
   expect(getDataYears([{ date: '2026-02-01' }, { date: '2025-06-01' }])).toEqual(['2026', '2025']);
   expect(getDataYears([{ date: 'nope' }])).toEqual([]);
-});
-
-test('resolveInitialYear는 DEFAULT 연도 데이터가 없으면 최신 데이터 연도로 폴백한다', () => {
-  expect(resolveInitialYear(['2025'])).toBe('2025'); // 2026 데이터 없음 → 최신(2025)
-  expect(resolveInitialYear(['2026', '2025'])).toBe('2026'); // 2026 있음 → 2026
-  expect(resolveInitialYear([])).toBe(DEFAULT_YEAR); // 데이터 없음 → 기본
 });
 
 test('getAvailableYears는 DEFAULT_YEAR를 항상 포함하고 내림차순 정렬한다', () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ function copyrightYears(): string {
 
 export const metadata: Metadata = {
   title: "OSSCA Chromium",
-  description: "2025 OSSCA 참여형 Chromium 프로젝트",
+  description: "2026 OSSCA 참여형 Chromium 프로젝트",
 };
 
 const NAV_LINKS = [

--- a/src/components/ContributionSearch.tsx
+++ b/src/components/ContributionSearch.tsx
@@ -4,12 +4,7 @@ import { useMemo, useState } from 'react';
 import type { ContributionStatus, SearchIndexItem } from '@/lib/types';
 import ContributionCard from '@/components/ContributionCard';
 import YearSelector from '@/components/YearSelector';
-import {
-  filterByYear,
-  getAvailableYears,
-  getDataYears,
-  resolveInitialYear,
-} from '@/lib/years';
+import { DEFAULT_YEAR, filterByYear, getAvailableYears } from '@/lib/years';
 
 type StatusFilter = 'all' | ContributionStatus;
 
@@ -25,7 +20,7 @@ export default function ContributionSearch({ items }: { items: SearchIndexItem[]
   const [status, setStatus] = useState<StatusFilter>('all');
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const years = useMemo(() => getAvailableYears(items), [items]);
-  const [year, setYear] = useState(() => resolveInitialYear(getDataYears(items)));
+  const [year, setYear] = useState(DEFAULT_YEAR);
 
   const allLabels = useMemo(() => {
     const set = new Set<string>();

--- a/src/components/ContributorView.tsx
+++ b/src/components/ContributorView.tsx
@@ -2,12 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import type { Contribution } from '@/lib/types';
-import {
-  filterByYear,
-  getAvailableYears,
-  getDataYears,
-  resolveInitialYear,
-} from '@/lib/years';
+import { DEFAULT_YEAR, filterByYear, getAvailableYears } from '@/lib/years';
 import ContributionCard from '@/components/ContributionCard';
 import YearSelector from '@/components/YearSelector';
 
@@ -17,9 +12,7 @@ export default function ContributorView({
   contributions: Contribution[];
 }) {
   const years = useMemo(() => getAvailableYears(contributions), [contributions]);
-  const [year, setYear] = useState(() =>
-    resolveInitialYear(getDataYears(contributions))
-  );
+  const [year, setYear] = useState(DEFAULT_YEAR);
   const filtered = useMemo(
     () => filterByYear(contributions, year),
     [contributions, year]

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -4,19 +4,14 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import type { SearchIndexItem } from '@/lib/types';
 import { computeStats } from '@/lib/stats';
-import {
-  filterByYear,
-  getAvailableYears,
-  getDataYears,
-  resolveInitialYear,
-} from '@/lib/years';
+import { DEFAULT_YEAR, filterByYear, getAvailableYears } from '@/lib/years';
 import ContributionCard from '@/components/ContributionCard';
 import ContributorAvatar from '@/components/ContributorAvatar';
 import YearSelector from '@/components/YearSelector';
 
 export default function HomeView({ items }: { items: SearchIndexItem[] }) {
   const years = useMemo(() => getAvailableYears(items), [items]);
-  const [year, setYear] = useState(() => resolveInitialYear(getDataYears(items)));
+  const [year, setYear] = useState(DEFAULT_YEAR);
   const filtered = useMemo(() => filterByYear(items, year), [items, year]);
   const stats = useMemo(() => computeStats(filtered), [filtered]);
   const recent = filtered.slice(0, 3);

--- a/src/components/StatsView.tsx
+++ b/src/components/StatsView.tsx
@@ -3,18 +3,13 @@
 import { useMemo, useState } from 'react';
 import type { SearchIndexItem } from '@/lib/types';
 import { computeStats } from '@/lib/stats';
-import {
-  filterByYear,
-  getAvailableYears,
-  getDataYears,
-  resolveInitialYear,
-} from '@/lib/years';
+import { DEFAULT_YEAR, filterByYear, getAvailableYears } from '@/lib/years';
 import StatsCharts from '@/components/StatsCharts';
 import YearSelector from '@/components/YearSelector';
 
 export default function StatsView({ items }: { items: SearchIndexItem[] }) {
   const years = useMemo(() => getAvailableYears(items), [items]);
-  const [year, setYear] = useState(() => resolveInitialYear(getDataYears(items)));
+  const [year, setYear] = useState(DEFAULT_YEAR);
   const stats = useMemo(() => computeStats(filterByYear(items, year)), [items, year]);
 
   return (

--- a/src/lib/years.ts
+++ b/src/lib/years.ts
@@ -34,13 +34,6 @@ export function getAvailableYears(items: { date: unknown }[]): string[] {
   return [...set].sort((a, b) => b.localeCompare(a));
 }
 
-// Initial selected year: prefer DEFAULT_YEAR when it has data, otherwise the
-// newest year that actually has data, falling back to DEFAULT_YEAR when empty.
-export function resolveInitialYear(dataYears: string[]): string {
-  if (dataYears.includes(DEFAULT_YEAR)) return DEFAULT_YEAR;
-  return dataYears[0] ?? DEFAULT_YEAR;
-}
-
 // When year === 'all' return everything, otherwise only the matching year.
 export function filterByYear<T extends { date: unknown }>(items: T[], year: string): T[] {
   if (year === 'all') return items;


### PR DESCRIPTION
수정한 이슈: 없음

## Summary

연도 필터 초기값을 데이터 유무와 무관하게 항상 2026으로 고정.

- **기본 연도**: 홈·패치·통계·기여자 페이지 모두 2026으로 시작
- **폴백 제거**: "데이터 있는 최신 연도"로 되돌아가던 로직 삭제
- **과거 조회 유지**: 연도 버튼에 2025 계속 노출, 클릭으로 전환 가능

## Background

- **문제**: 기여 데이터가 전부 2025년이라, 연도 필터가 데이터 있는 최신 연도로 폴백 → 모든 페이지가 2025로 시작
- **목표**: 2026 시즌 시작에 맞춰 사이트 첫 화면이 항상 2026을 보여주도록 변경

## Changes

- **폴백 함수 삭제**: `resolveInitialYear` 제거 (`src/lib/years.ts`) 및 해당 테스트 정리
- **초기 연도 고정**: HomeView·ContributionSearch·StatsView·ContributorView의 초기 연도를 `DEFAULT_YEAR`('2026')로 고정
- **메타 설명**: "2026 OSSCA 참여형 Chromium 프로젝트"로 갱신 (`src/app/layout.tsx`)

## Test

- [x] Jest: 31 suites / 109 tests 통과
- [x] ESLint: 경고 0
- [x] `npm run build` 정적 export 성공
- [x] 프리렌더된 HTML에서 2026 버튼 `aria-pressed="true"` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
