### PR TITLE
feat: Add Google Analytics for production host

### DIFF
--- a/__tests__/components/Analytics.test.tsx
+++ b/__tests__/components/Analytics.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import Analytics from '@/components/Analytics';
+
+jest.mock('@next/third-parties/google', () => ({
+  GoogleAnalytics: ({ gaId }: { gaId: string }) => (
+    <div data-testid="google-analytics" data-ga-id={gaId} />
+  ),
+}));
+
+const originalLocation = window.location;
+
+function mockHostname(hostname: string) {
+  Object.defineProperty(window, 'location', {
+    value: new URL(`https://${hostname}/contributions/`),
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: originalLocation,
+    writable: true,
+  });
+});
+
+describe('Analytics', () => {
+  it('localhost에서는 GA를 렌더링하지 않는다', () => {
+    // jsdom 기본 URL은 http://localhost/
+    render(<Analytics />);
+    expect(screen.queryByTestId('google-analytics')).not.toBeInTheDocument();
+  });
+
+  it('포크 배포 호스트에서는 GA를 렌더링하지 않는다', () => {
+    mockHostname('someone-else.github.io');
+    render(<Analytics />);
+    expect(screen.queryByTestId('google-analytics')).not.toBeInTheDocument();
+  });
+
+  it('프로덕션 호스트에서만 GA를 측정 ID와 함께 렌더링한다', () => {
+    mockHostname('ossca-chromium.github.io');
+    render(<Analytics />);
+    expect(screen.getByTestId('google-analytics')).toHaveAttribute(
+      'data-ga-id',
+      'G-5T5Q4PMYKM'
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "contributions",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^15.3.1",
         "@tailwindcss/typography": "^0.5.16",
         "@types/sanitize-html": "^2.16.1",
         "gh-pages": "^6.1.1",
@@ -1926,6 +1927,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.1.tgz",
+      "integrity": "sha512-8v1pAtRjcaCbs80qcYLLCrSsECgeSb0WMU0J3pMBYNavG3Y3yQOgFog18nVgiNrNB20HkyrScquWsy8gcdiGRA==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -12205,6 +12218,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deploy": "next build && next export && touch out/.nojekyll && gh-pages -d out --dotfiles"
   },
   "dependencies": {
+    "@next/third-parties": "^15.3.1",
     "@tailwindcss/typography": "^0.5.16",
     "@types/sanitize-html": "^2.16.1",
     "gh-pages": "^6.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import Image from "next/image";
 import LogoImage from "../../public/logo.png";
 import ThemeToggle from "@/components/ThemeToggle";
+import Analytics from "@/components/Analytics";
 import "./globals.css";
 
 const roboto = Roboto({ subsets: ["latin"], weight: ["400", "500", "700"] });
@@ -132,6 +133,7 @@ export default function RootLayout({
             </div>
           </div>
         </footer>
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { GoogleAnalytics } from '@next/third-parties/google';
+import { useEffect, useState } from 'react';
+
+const GA_ID = 'G-5T5Q4PMYKM';
+// Only the production GitHub Pages host should report analytics;
+// localhost and forked deployments must not pollute the data.
+const PROD_HOSTNAME = 'ossca-chromium.github.io';
+
+export default function Analytics() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(window.location.hostname === PROD_HOSTNAME);
+  }, []);
+
+  if (!enabled) return null;
+  return <GoogleAnalytics gaId={GA_ID} />;
+}


### PR DESCRIPTION
수정한 이슈: 없음

## Summary

프로덕션 호스트에서만 로드되는 Google Analytics(GA4) 도입.

- **측정 ID**: G-5T5Q4PMYKM (`@next/third-parties` GoogleAnalytics 사용)
- **로드 조건**: 마운트 후 `window.location.hostname === 'ossca-chromium.github.io'`일 때만
- **오염 방지**: localhost 개발·포크 배포(`{username}.github.io`) 트래픽은 통계에 미포함

## Background

- **문제**: 정적 export(GitHub Pages) 사이트라 방문 통계가 전혀 없음
- **제약**: 정적 HTML에 gtag를 직접 넣으면 개발·포크 환경 접속까지 전부 집계되어 데이터 오염
- **해결**: 클라이언트 컴포넌트로 감싸 런타임에 호스트를 판별, 프로덕션 호스트에서만 GA 로드

## Changes

- **Analytics 컴포넌트 신규**: 마운트 후 호스트 판별, 프로덕션에서만 GoogleAnalytics 렌더
- **레이아웃 연결**: RootLayout body 끝에 Analytics 추가 (모든 페이지 적용)
- **의존성**: `@next/third-parties@15.3.1` 추가
- **테스트 3개**: localhost 미렌더 / 포크 호스트 미렌더 / 프로덕션 호스트에서 측정 ID와 함께 렌더

## Test

- [x] `npm test` — 32 suites / 117 tests 통과 (Analytics 3개 포함)
- [x] `npm run lint` — 경고·에러 없음
- [x] `npm run build` — 성공, 정적 HTML 산출물에 gtag 미포함(프로덕션 호스트에서만 런타임 로드) 확인
