### PR TITLE
docs: Allow semantic commit prefixes for repo commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,5 +53,10 @@ Contribution frontmatter (see `data/contributions/template.md`): `title`, `date`
 
 ## Commit & workflow conventions
 
-- **Do not use semantic-commit prefixes** (`feat:`/`fix:`/`chore:`). Per `CONTRIBUTING.md`, this repo follows Chromium style: subject starts with a present-tense verb (Add/Fix/Implement), capitalized first letter, no trailing period, wrapped at 72 columns, with a blank line after the subject. Optional module tag as `css: Fix ...` or `[CSS] Fix ...`.
+- **Use semantic-commit prefixes**, chosen by what changed:
+  - Site code (`src/`, `scripts/`, config, tests — the GitHub Pages app): `feat:` / `fix:` / `refactor:` / `chore:` / `test:`
+  - Program data (`data/**` — contributions, meeting notes, docs translations): `data:`
+  - Repo docs (`README.md`, `CONTRIBUTING.md`, `CLAUDE.md`): `docs:`
+  - After the prefix, keep the existing subject style: present-tense verb, capitalized, no trailing period, 72-column wrap, blank line after the subject. Examples: `feat: Add Google Analytics for production host`, `data: Add contribution 6721390`.
+- The "commit message rule" section in `CONTRIBUTING.md` (no semantic prefixes, Chromium style) applies to **Chromium Gerrit patches** (`git cl upload`), not to commits in this repo — do not apply it here.
 - Fork-based flow: `upstream` = `OSSCA-chromium/contributions`; local `main` tracks `upstream/main`. Branch names use `YYMMDD-topic`. Push to `origin` (your fork) and open a PR against upstream `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,22 @@ $ git push origin 250420-test
 
 5. Pull Request 생성
 
+### 이 저장소의 commit message rule
+
+이 저장소(contributions)에 커밋할 때는 변경 대상에 따라 semantic prefix를 붙입니다.
+
+| 변경 대상                                                     | prefix                                      |
+| ------------------------------------------------------------- | ------------------------------------------- |
+| 사이트 코드 (`src/`, `scripts/`, 설정, 테스트)                | `feat:` `fix:` `refactor:` `chore:` `test:` |
+| 프로그램 데이터 (`data/**` — contribution, 회의록, 문서 번역) | `data:`                                     |
+| 저장소 문서 (README, CONTRIBUTING 등)                         | `docs:`                                     |
+
+- prefix 뒤 제목은 현재형 동사(Add, Fix, Implement 등)로 시작, 첫 글자는 대문자, 마침표 없이
+- 제목 다음에 빈 줄 하나, 본문은 72자에서 줄바꿈
+- 예시: `feat: Add Google Analytics for production host`, `data: Add contribution 6721390`
+
+Chromium Gerrit에 업로드하는 패치는 이 규칙이 아니라 아래 [commit message rule](#commit-message-rule)을 따릅니다.
+
 ## Chromium Issue 진행
 
 ### 이슈 생성 또는 기존 이슈 선택하기
@@ -66,6 +82,8 @@ $ git push origin 250420-test
 - [ ] 멘토 이메일 주소: eui-sang.lim@samsung.com
 
 ### commit message rule
+
+이 규칙은 **Chromium Gerrit에 업로드하는 패치**에 적용됩니다. 이 저장소 커밋에는 [이 저장소의 commit message rule](#이-저장소의-commit-message-rule)을 따릅니다.
 
 ```
 Summary of change (one line)


### PR DESCRIPTION
수정한 이슈: 없음

## Summary

이 저장소 자체 커밋에 semantic prefix를 사용하도록 커밋 컨벤션 정립.

- **사이트 코드**: `feat:` / `fix:` / `refactor:` / `chore:` / `test:`
- **프로그램 데이터**(`data/**`): `data:`
- **저장소 문서**: `docs:`

## Background

- **기존 문제**: CLAUDE.md가 CONTRIBUTING.md를 근거로 semantic prefix 금지를 리포 전체에 적용
- **원인**: 해당 규칙은 Chromium Gerrit 패치(`git cl upload`)용 규칙의 과잉 일반화
- **정리**: Gerrit 패치 규칙과 저장소 커밋 규칙을 분리, 각각의 적용 범위를 명시

## Changes

- **CONTRIBUTING.md**: "공통" 섹션에 저장소용 commit message rule 신설(prefix 표 + 제목 작성 규칙), 기존 Gerrit용 "commit message rule" 섹션에 적용 범위 명시와 상호 링크 추가
- **CLAUDE.md**: 동일 내용으로 Commit & workflow conventions 갱신

## Test

- [x] `npm run lint:md` 대상 아님(문서 규칙 변경만) — 마크다운은 pre-commit prettier 통과
