### PR TITLE
feat: Add Google Search Console verification meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ function copyrightYears(): string {
 export const metadata: Metadata = {
   title: "OSSCA Chromium",
   description: "2026 OSSCA 참여형 Chromium 프로젝트",
+  verification: { google: "6lATKwyH4W3FqgJMSzFuiaY0zgSyYNmgpPqSTgB2PmE" },
 };
 
 const NAV_LINKS = [


### PR DESCRIPTION
수정한 이슈: 없음

## Summary

Google Search Console 소유권 확인을 위해 `google-site-verification` 메타 태그를 정적 HTML `<head>`에 추가.

- **문제**: Search Console의 "Google 애널리틱스" 확인 방식이 추적 코드를 찾지 못함
- **원인**: 기존 GA(gtag)는 프로덕션 호스트에서만 런타임 로드 — 정적 HTML에 부재
- **해결**: Next.js metadata API(`verification.google`)로 "HTML 태그" 확인 방식 사용

## Background

- **목적**: Google Search Console에 사이트 소유권 등록
- **제약**: 이 사이트는 정적 export(GitHub Pages)라 런타임 주입 스크립트는 확인 도구가 읽지 못함
- **무해성**: 이 태그는 추적 코드가 아닌 소유권 표식 — localhost·포크 배포에 포함돼도 영향 없음
- **후속 계획**: 소유권 확인 후 GA4 ↔ Search Console 제품 링크 연결 예정

## Changes

- **`src/app/layout.tsx`**: metadata에 `verification: { google: "..." }` 1줄 추가 — 빌드 시 모든 페이지 `<head>`에 `google-site-verification` 메타 태그 포함

## Test

- [x] `npm test` 전체 통과 (32 suites / 117 tests)
- [x] `npm run lint` 클린
- [x] `npm run build` 성공 (정적 export 123 페이지)
- [x] `out/index.html` `<head>`에 `google-site-verification` 메타 태그 포함 확인
