### PR TITLE
feat: Color Sundays and Korean holidays red in schedule calendar

### DIFF
--- a/__tests__/components/CalendarGrid.test.tsx
+++ b/__tests__/components/CalendarGrid.test.tsx
@@ -91,3 +91,19 @@ test('today가 null이면 오늘 마커가 없다', () => {
   const { container } = renderGrid({ today: null });
   expect(container.querySelector('[data-today="true"]')).toBeNull();
 });
+
+test('요일 헤더는 일요일만 붉게 표시한다', () => {
+  renderGrid();
+  expect(screen.getByText('일')).toHaveClass('text-error');
+  expect(screen.getByText('월')).not.toHaveClass('text-error');
+});
+
+test('일요일과 공휴일 날짜 숫자는 붉게, 평일은 기본색으로 표시한다', () => {
+  const { container } = renderGrid();
+  const redDays = Array.from(
+    container.querySelectorAll('a.text-error, span.text-error')
+  ).map((el) => el.textContent);
+  expect(redDays).toContain('5'); // 2026-07-05 (일)
+  expect(redDays).toContain('17'); // 2026-07-17 제헌절
+  expect(redDays).not.toContain('1'); // 2026-07-01 (수) — 일반 평일
+});

--- a/__tests__/holidays.test.ts
+++ b/__tests__/holidays.test.ts
@@ -1,0 +1,19 @@
+import { isHoliday } from '@/lib/holidays';
+
+test('법정 공휴일이면 true를 반환한다', () => {
+  expect(isHoliday('2025-01-01')).toBe(true); // 신정
+  expect(isHoliday('2026-02-17')).toBe(true); // 설날 연휴 가운데 날
+  expect(isHoliday('2026-07-17')).toBe(true); // 제헌절 (2026년부터 재지정)
+});
+
+test('대체공휴일과 임시공휴일도 true를 반환한다', () => {
+  expect(isHoliday('2025-06-03')).toBe(true); // 대통령선거 임시공휴일
+  expect(isHoliday('2025-10-08')).toBe(true); // 추석 대체공휴일
+  expect(isHoliday('2026-08-17')).toBe(true); // 광복절 대체공휴일
+});
+
+test('공휴일이 아닌 날은 false를 반환한다', () => {
+  expect(isHoliday('2025-07-17')).toBe(false); // 제헌절 공휴일 적용은 2026년부터
+  expect(isHoliday('2026-09-28')).toBe(false); // 추석은 토요일 겹침 — 대체공휴일 없음
+  expect(isHoliday('2026-07-16')).toBe(false); // 평일
+});

--- a/src/components/CalendarGrid.tsx
+++ b/src/components/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import type { Meeting } from '@/lib/types';
 import { buildMonthGrid } from '@/lib/calendar';
+import { isHoliday } from '@/lib/holidays';
 import { periodColorMap, TYPE_CIRCLE } from '@/lib/periodColors';
 import EventPopover from '@/components/EventPopover';
 
@@ -29,8 +30,13 @@ export default function CalendarGrid({ year, month, meetings, today }: CalendarG
         {year}년 {month}월
       </div>
       <div className="grid grid-cols-7">
-        {WEEKDAYS.map((w) => (
-          <div key={w} className="py-1 text-center text-xs text-on-surface-variant">
+        {WEEKDAYS.map((w, i) => (
+          <div
+            key={w}
+            className={`py-1 text-center text-xs ${
+              i === 0 ? 'text-error' : 'text-on-surface-variant'
+            }`}
+          >
             {w}
           </div>
         ))}
@@ -52,6 +58,10 @@ export default function CalendarGrid({ year, month, meetings, today }: CalendarG
               // periods (Challenges/Masters) only show on days without one.
               const popoverEvents = dayPoints.length ? dayPoints : covering;
               const isToday = today === d.date;
+              // Sundays and Korean public holidays render in the muted
+              // red `error` token; everything else keeps `on-surface`.
+              const dayColor =
+                ci === 0 || isHoliday(d.date) ? 'text-error' : 'text-on-surface';
 
               const band = covering[0];
               const bandColor = band ? (periodColor.get(band.slug)?.bar ?? '') : '';
@@ -88,7 +98,7 @@ export default function CalendarGrid({ year, month, meetings, today }: CalendarG
                     // page (point events win over covering periods).
                     <Link
                       href={`/schedule/${popoverEvents[0].slug}`}
-                      className={`relative z-10 flex h-8 w-8 items-center justify-center rounded-full text-sm text-on-surface ${pointCircle} ${
+                      className={`relative z-10 flex h-8 w-8 items-center justify-center rounded-full text-sm ${dayColor} ${pointCircle} ${
                         isToday ? 'font-bold ring-2 ring-primary' : ''
                       }`}
                     >
@@ -96,7 +106,7 @@ export default function CalendarGrid({ year, month, meetings, today }: CalendarG
                     </Link>
                   ) : (
                     <span
-                      className={`relative z-10 flex h-8 w-8 items-center justify-center rounded-full text-sm text-on-surface ${pointCircle} ${
+                      className={`relative z-10 flex h-8 w-8 items-center justify-center rounded-full text-sm ${dayColor} ${pointCircle} ${
                         isToday ? 'font-bold ring-2 ring-primary' : ''
                       }`}
                     >

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -1,0 +1,53 @@
+// Korean public holidays covering the schedule data range (2025-2026).
+// Includes holiday runs (Seollal/Chuseok), substitute holidays, election
+// days, and temporary holidays. When meeting data grows past 2026, append
+// that year's dates here.
+const KR_HOLIDAYS = new Set<string>([
+  // 2025
+  '2025-01-01', // New Year's Day
+  '2025-01-27', // temporary holiday (Seollal bridge)
+  '2025-01-28', // Seollal
+  '2025-01-29', // Seollal
+  '2025-01-30', // Seollal
+  '2025-03-01', // Independence Movement Day
+  '2025-03-03', // substitute (Independence Movement Day)
+  '2025-05-05', // Children's Day & Buddha's Birthday
+  '2025-05-06', // substitute
+  '2025-06-03', // presidential election (temporary holiday)
+  '2025-06-06', // Memorial Day
+  '2025-08-15', // Liberation Day
+  '2025-10-03', // National Foundation Day
+  '2025-10-05', // Chuseok
+  '2025-10-06', // Chuseok
+  '2025-10-07', // Chuseok
+  '2025-10-08', // substitute (Chuseok)
+  '2025-10-09', // Hangul Day
+  '2025-12-25', // Christmas
+  // 2026
+  '2026-01-01', // New Year's Day
+  '2026-02-16', // Seollal
+  '2026-02-17', // Seollal
+  '2026-02-18', // Seollal
+  '2026-03-01', // Independence Movement Day (Sun)
+  '2026-03-02', // substitute (Independence Movement Day)
+  '2026-05-05', // Children's Day
+  '2026-05-24', // Buddha's Birthday (Sun)
+  '2026-05-25', // substitute (Buddha's Birthday)
+  '2026-06-03', // nationwide local elections
+  '2026-06-06', // Memorial Day (Sat; no substitute by law)
+  '2026-07-17', // Constitution Day (public holiday again since 2026)
+  '2026-08-15', // Liberation Day (Sat)
+  '2026-08-17', // substitute (Liberation Day)
+  '2026-09-24', // Chuseok
+  '2026-09-25', // Chuseok
+  '2026-09-26', // Chuseok (Sat; Seollal/Chuseok substitute only for Sun)
+  '2026-10-03', // National Foundation Day (Sat)
+  '2026-10-05', // substitute (National Foundation Day)
+  '2026-10-09', // Hangul Day
+  '2026-12-25', // Christmas
+]);
+
+// True when the given YYYY-MM-DD date is a Korean public holiday.
+export function isHoliday(date: string): boolean {
+  return KR_HOLIDAYS.has(date);
+}


### PR DESCRIPTION
수정한 이슈: 없음 (달력 UX 개선)

## Summary

/schedule 달력에서 일요일과 한국 공휴일을 빨간색으로 표시해 쉬는 날을 한눈에 구분할 수 있게 한다.

- **일요일 표시**: 요일 헤더 '일'과 일요일 날짜 숫자를 빨간색으로 표시
- **공휴일 표시**: 2025·2026년 한국 공휴일(설·추석 연휴, 대체공휴일, 선거일, 임시공휴일, 재지정된 제헌절 포함) 날짜도 동일하게 빨간색 처리
- **다크 모드 대응**: 기존 테마 토큰 `text-error`(라이트 `#d93025` / 다크 `#f28b82`) 사용으로 자동 전환

## Background

- **문제**: 일정 달력에서 모든 날짜가 같은 색이라 쉬는 날(일요일·공휴일)을 구분하기 어려움
- **제약**: 정적 export 사이트라 런타임 공휴일 API 호출 불가 → 공휴일을 하드코딩 상수(Set)로 관리

## Changes

- **공휴일 데이터**: 2025·2026년 한국 공휴일 Set 상수와 `isHoliday()` 헬퍼 추가
- **달력 색상**: 요일 헤더 '일'과 일요일·공휴일 날짜 숫자에 `text-error` 색상 적용

## Test

- [x] `isHoliday()` 단위 테스트 3개 + 달력 컴포넌트 테스트 2개 추가
- [x] 전체 Jest 테스트 122개 통과
- [x] `next lint` 클린, 정적 빌드 성공
