### PR TITLE
docs: Add contribution record guide and contributions: prefix rule

### DIFF
--- a/.github/ISSUE_TEMPLATE/chromium-contribution-from-issue-tracker.md
+++ b/.github/ISSUE_TEMPLATE/chromium-contribution-from-issue-tracker.md
@@ -24,3 +24,7 @@ assignees: ''
 **References**
 
 - .
+
+---
+
+패치를 Gerrit에 올린 뒤에는 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)에 따라 기여 내역을 사이트에 반영해 주세요.

--- a/.github/ISSUE_TEMPLATE/chromium-contribution-not-from-issue-tracker.md
+++ b/.github/ISSUE_TEMPLATE/chromium-contribution-not-from-issue-tracker.md
@@ -17,3 +17,7 @@ _어디서 어떻게 발견한 이슈인지 함께 적어주세요._
 **References**
 
 - .
+
+---
+
+패치를 Gerrit에 올린 뒤에는 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)에 따라 기여 내역을 사이트에 반영해 주세요.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,22 +5,4 @@
 ## 관련 이슈
 
 <!-- 관련 GitHub 이슈 번호 (예: #188). 없으면 "없음" -->
-
-## Checklist
-
-<!-- 해당하는 유형의 체크리스트만 남기고 나머지는 지워주세요 -->
-
-### 기여 기록 (`data/contributions/**`)
-
-[기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 따라 작성했는지 확인해 주세요.
-
-- [ ] 파일명이 `{ChromiumReviewId}.md` 형식이다
-- [ ] 템플릿 안내 주석(`# github.com/GitHubId` 등)과 `https://example.com` placeholder를 모두 지웠다
-- [ ] `npm run validate:data`, `npm run lint:md`가 통과한다
-- [ ] 커밋 메시지가 `contributions:` prefix를 사용한다 (예: `contributions: Add 6520751`)
-- [ ] frontmatter의 `status`가 현재 CL 상태와 일치한다 (`in review` / `merged`)
-
-### 사이트 코드·문서·기타 데이터
-
-- [ ] `npm test`, `npm run lint`, `npm run build`가 통과한다
-- [ ] 커밋 메시지 prefix가 [CONTRIBUTING.md](https://github.com/OSSCA-chromium/contributions/blob/main/CONTRIBUTING.md) 규칙과 일치한다
+<!-- 기여 기록 PR은 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 참고하세요 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,26 @@
-수정한 이슈:
+## Summary
+
+<!-- 무엇을 왜 바꿨는지 1~3줄로 적어주세요 -->
+
+## 관련 이슈
+
+<!-- 관련 GitHub 이슈 번호 (예: #188). 없으면 "없음" -->
+
+## Checklist
+
+<!-- 해당하는 유형의 체크리스트만 남기고 나머지는 지워주세요 -->
+
+### 기여 기록 (`data/contributions/**`)
+
+[기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 따라 작성했는지 확인해 주세요.
+
+- [ ] 파일명이 `{ChromiumReviewId}.md` 형식이다
+- [ ] 템플릿 안내 주석(`# github.com/GitHubId` 등)과 `https://example.com` placeholder를 모두 지웠다
+- [ ] `npm run validate:data`, `npm run lint:md`가 통과한다
+- [ ] 커밋 메시지가 `contributions:` prefix를 사용한다 (예: `contributions: Add 6520751`)
+- [ ] frontmatter의 `status`가 현재 CL 상태와 일치한다 (`in review` / `merged`)
+
+### 사이트 코드·문서·기타 데이터
+
+- [ ] `npm test`, `npm run lint`, `npm run build`가 통과한다
+- [ ] 커밋 메시지 prefix가 [CONTRIBUTING.md](https://github.com/OSSCA-chromium/contributions/blob/main/CONTRIBUTING.md) 규칙과 일치한다

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,9 @@ Contribution frontmatter (see `data/contributions/template.md`): `title`, `date`
 
 - **Use semantic-commit prefixes**, chosen by what changed:
   - Site code (`src/`, `scripts/`, config, tests — the GitHub Pages app): `feat:` / `fix:` / `refactor:` / `chore:` / `test:`
-  - Program data (`data/**` — contributions, meeting notes, docs translations): `data:`
+  - Contribution records (`data/contributions/**`): `contributions:`
+  - Program data (other `data/**` — meeting notes, docs translations): `data:`
   - Repo docs (`README.md`, `CONTRIBUTING.md`, `CLAUDE.md`): `docs:`
-  - After the prefix, keep the existing subject style: present-tense verb, capitalized, no trailing period, 72-column wrap, blank line after the subject. Examples: `feat: Add Google Analytics for production host`, `data: Add contribution 6721390`.
+  - After the prefix, keep the existing subject style: present-tense verb, capitalized, no trailing period, 72-column wrap, blank line after the subject. Examples: `feat: Add Google Analytics for production host`, `contributions: Add 6520751`, `data: Add meeting note 2026-07-25`.
 - The "commit message rule" section in `CONTRIBUTING.md` (no semantic prefixes, Chromium style) applies to **Chromium Gerrit patches** (`git cl upload`), not to commits in this repo — do not apply it here.
 - Fork-based flow: `upstream` = `OSSCA-chromium/contributions`; local `main` tracks `upstream/main`. Branch names use `YYMMDD-topic`. Push to `origin` (your fork) and open a PR against upstream `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,16 @@ $ git push origin 250420-test
 
 이 저장소(contributions)에 커밋할 때는 변경 대상에 따라 semantic prefix를 붙입니다.
 
-| 변경 대상                                                     | prefix                                      |
-| ------------------------------------------------------------- | ------------------------------------------- |
-| 사이트 코드 (`src/`, `scripts/`, 설정, 테스트)                | `feat:` `fix:` `refactor:` `chore:` `test:` |
-| 프로그램 데이터 (`data/**` — contribution, 회의록, 문서 번역) | `data:`                                     |
-| 저장소 문서 (README, CONTRIBUTING 등)                         | `docs:`                                     |
+| 변경 대상                                             | prefix                                      |
+| ----------------------------------------------------- | ------------------------------------------- |
+| 사이트 코드 (`src/`, `scripts/`, 설정, 테스트)        | `feat:` `fix:` `refactor:` `chore:` `test:` |
+| 기여 기록 (`data/contributions/**`)                   | `contributions:`                            |
+| 프로그램 데이터 (그 외 `data/**` — 회의록, 문서 번역) | `data:`                                     |
+| 저장소 문서 (README, CONTRIBUTING 등)                 | `docs:`                                     |
 
 - prefix 뒤 제목은 현재형 동사(Add, Fix, Implement 등)로 시작, 첫 글자는 대문자, 마침표 없이
 - 제목 다음에 빈 줄 하나, 본문은 72자에서 줄바꿈
-- 예시: `feat: Add Google Analytics for production host`, `data: Add contribution 6721390`
+- 예시: `feat: Add Google Analytics for production host`, `contributions: Add 6520751`, `data: Add meeting note 2026-07-25`
 
 Chromium Gerrit에 업로드하는 패치는 이 규칙이 아니라 아래 [commit message rule](#commit-message-rule)을 따릅니다.
 
@@ -109,8 +110,12 @@ Bug: 123456
 
 ### 패치 Gerrit 업로드 후 진행
 
-1. `data/contributions/template.md` 파일을 `data/contribtutions/{ChromiumReviewId}.md` 파일로 복사합니다.
-2. 내용을 채우고 GitHub Pull Request 로 올려주세요.
+기여 내역을 사이트에 반영하는 전체 절차는 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 따르세요. 요약:
+
+1. `data/contributions/template.md` 파일을 `data/contributions/{ChromiumReviewId}.md` 파일로 복사하고 내용을 채웁니다 (템플릿 안내 주석은 모두 제거).
+2. `npm run validate:data`와 `npm run lint:md`로 로컬 검증합니다.
+3. `contributions:` prefix 커밋으로 Pull Request를 올립니다 (예: `contributions: Add 6520751`).
+4. Gerrit에서 CL이 merge되면 후속 PR로 `status: merged`로 갱신합니다.
 
 ## 웹사이트 실행 및 확인
 

--- a/data/docs/contribution-record.md
+++ b/data/docs/contribution-record.md
@@ -1,0 +1,135 @@
+---
+title: 기여 기록하기
+order: 5
+group: 가이드
+description: Gerrit CL 업로드 후 기여 내역을 이 사이트에 반영하는 절차
+---
+
+Gerrit에 CL을 올렸다면 기여 내역을 `data/contributions/`에 기록해 이 사이트에
+반영합니다. 기록된 내역은 [기여 목록](/contributions/patches/)과
+[통계](/contributions/stats/), 기여자 페이지에 자동으로 집계됩니다.
+
+> 저장소 fork·clone·upstream 설정이 아직이라면
+> [CONTRIBUTING.md](https://github.com/OSSCA-chromium/contributions/blob/main/CONTRIBUTING.md)의
+> "공통" 섹션을 먼저 따라 하세요.
+
+## 0. Gerrit 기본 설정 — 새 CL을 Work in Progress로 (최초 1회)
+
+[Gerrit 설정](https://chromium-review.googlesource.com/settings/)의 Preferences에서
+**Set new changes to "work in progress" by default**를 체크하세요.
+
+- 체크해 두면 `git cl upload`로 올린 CL이 리뷰어에게 바로 노출되지 않는
+  WIP(Work in Progress) 상태로 만들어집니다.
+- 멘토에게 커밋 메시지와 변경 내용을 확인받은 뒤, Gerrit 화면에서
+  **Start Review**를 눌러 리뷰를 시작합니다.
+
+## 1. 기록 파일 만들기
+
+`data/contributions/template.md`를 `{ChromiumReviewId}.md`로 복사합니다.
+
+```bash
+cp data/contributions/template.md data/contributions/6520751.md
+```
+
+`ChromiumReviewId`는 Gerrit URL의 마지막 숫자입니다.
+예: `https://chromium-review.googlesource.com/c/chromium/src/+/6520751` → `6520751.md`
+
+### frontmatter 작성 규칙
+
+| 필드               | 값                                     | 예                          |
+| ------------------ | -------------------------------------- | --------------------------- |
+| `title`            | Gerrit에 올린 commit 제목 그대로       | `"Fix siso_tips.md link"`   |
+| `date`             | CL 업로드 날짜, `YYYY-MM-DD`           | `2026-07-25`                |
+| `author`           | 본인 GitHub ID                         | `amoseui`                   |
+| `contribution_url` | `https://crrev.com/c/{ChromiumReviewId}` | `https://crrev.com/c/6520751` |
+| `labels`           | 수정한 디렉터리 + 작업 성격            | `["docs", "fix"]`           |
+| `status`           | `in review` 또는 `merged`              | `in review`                 |
+
+- `date`는 반드시 유효한 `YYYY-MM-DD` 형식이어야 합니다. 잘못된 날짜(예:
+  `2025-05-D8`)는 CI에서 걸리고, 통과하더라도 목록 정렬을 조용히 깨뜨립니다.
+- `author`는 기여자 페이지 링크와 아바타에 그대로 사용되므로 정확한 GitHub
+  ID를 적으세요.
+- **템플릿의 안내 주석(`# github.com/GitHubId`, `# Add XXXXX from ...` 등)은
+  모두 지우세요.**
+
+### 본문 작성
+
+- 문제 설명 / 해결 내용 / 테스트 방법 / 배운 점 / 참고 자료 — 각 섹션의 안내
+  문구를 실제 내용으로 교체합니다.
+- 해당 사항이 없는 섹션(예: 문서 수정이라 테스트가 없는 경우)은 제거해도
+  됩니다.
+- 템플릿에 있는 `https://example.com` 같은 placeholder 링크는 반드시
+  제거하세요.
+
+## 2. 로컬 검증
+
+PR을 올리기 전에 CI 검사 중 데이터 관련 두 가지를 로컬에서 돌려봅니다.
+(CI는 이 외에 테스트·ESLint·빌드도 실행하지만, `data/contributions/`만
+추가했다면 아래 두 가지가 통과하면 충분합니다.)
+
+```bash
+npm run validate:data   # frontmatter 검사
+npm run lint:md         # 마크다운 린트
+```
+
+렌더링을 직접 확인하려면 `npm run dev` 실행 후
+`http://localhost:3000/contributions/patches/`에서 본인 항목을 열어보세요.
+
+## 3. PR 올리기
+
+```bash
+git checkout -b 250725-contribution-6520751   # 브랜치명: YYMMDD-주제
+git add data/contributions/6520751.md
+git commit -m "contributions: Add 6520751"
+git push origin 250725-contribution-6520751
+```
+
+- 커밋 메시지: `data/contributions/` 변경은 **`contributions:` prefix**를
+  사용합니다. 제목은 현재형 동사로 시작, 첫 글자 대문자, 마침표 없음.
+- push 후 GitHub에서 본인 fork 페이지에 뜨는 **Compare & pull request**
+  버튼을 누르거나, fork의 해당 브랜치에서 **Contribute → Open pull
+  request**로 PR을 생성합니다.
+- base가 `OSSCA-chromium/contributions`의 `main`인지 확인하세요 (본인 fork의
+  `main`이 아닙니다).
+- CI(테스트·린트·데이터 검증)가 통과하는지 확인하고, 실패하면 로그를 보고
+  수정 커밋을 추가합니다.
+- PR이 merge되면 사이트에 자동 배포됩니다(수 분 소요).
+
+## 4. CL이 merge되면 — status 갱신
+
+Gerrit에서 CL이 최종 merge되면, 후속 PR로 `status`만 갱신합니다.
+
+```bash
+git checkout main && git pull
+git checkout -b 250801-merged-6520751
+```
+
+`data/contributions/6520751.md`의 frontmatter에서 `status: in review`를
+`status: merged`로 수정한 뒤, 같은 방식으로 커밋·push·PR을 올립니다.
+
+```bash
+git commit -am "contributions: Mark 6520751 as merged"
+git push origin 250801-merged-6520751
+```
+
+## 5. GitHub 이슈·프로젝트 보드
+
+- 담당한 GitHub 이슈에 **Gerrit CL 링크**와 **기여 기록 PR 링크**를 코멘트로
+  남기세요.
+- 프로젝트 보드(2026 Chromium Issues)의 Status 이동과 이슈 close는 멘토가
+  처리합니다. 직접 옮기지 않아도 됩니다.
+
+## 자주 하는 실수
+
+작년(2025) 기록에서 실제로 반복됐던 실수들입니다.
+
+1. **템플릿 주석 잔재** — `author: ppirabbang # github.com/GitHubId`처럼
+   안내 주석을 지우지 않고 제출.
+2. **placeholder 링크 방치** — 참고 자료에
+   `[관련 문서 링크](https://example.com)`가 그대로 남음.
+3. **섹션 내용 뒤바뀜** — "테스트 방법" 섹션에 배운 점을 작성하는 등 안내
+   문구와 내용이 어긋남.
+4. **status 미갱신** — CL은 merge됐는데 기록은 계속 `in review`로 남아 통계가
+   틀어짐.
+5. **커밋 메시지 형식** — `Create 6619930.md`, `Update 6508290.md` 같은 기본
+   메시지 사용. `contributions: Add 6619930` 형식을 지켜주세요.


### PR DESCRIPTION
수정한 이슈: 없음 (2주차 실습 대비 문서 정비)

## Summary

기여 기록 절차를 사이트 가이드 문서로 명문화하고, `data/contributions/**` 전용 커밋 prefix(`contributions:`)를 도입한다.

- **가이드 페이지**: "기여 기록하기" 문서를 `/docs/contribution-record/`에 신설 ("가이드" 그룹 5번째)
- **커밋 규칙**: `data/contributions/**` 변경은 `contributions:` prefix로 분리 (기존 `data:`에서 독립)
- **진입점 연결**: CONTRIBUTING.md·이슈 템플릿 2종에서 가이드로 링크

## Background

- **실습 임박**: 2026 OSSCA 참여형 2주차 실습(Chromium docs 깨진 링크 수정)을 앞두고, Gerrit CL 업로드 후 기여 내역을 이 사이트에 반영하는 절차가 CONTRIBUTING.md에 2줄뿐이었음
- **반복된 실수**: 작년(2025) 기록에서 템플릿 주석 잔재, placeholder 링크, status 미갱신, 커밋 메시지 비일관이 반복 → "자주 하는 실수" 섹션으로 명문화
- **부가 안내**: Gerrit "Set new changes to work in progress by default" 설정 안내 포함

## Changes

| 파일 | 변경 |
| --- | --- |
| `data/docs/contribution-record.md` | 신규 — 기여 기록 가이드 (4단계 절차 + 자주 하는 실수) |
| `CONTRIBUTING.md` | prefix 표에 `data/contributions/**` → `contributions:` 행 추가, "패치 Gerrit 업로드 후 진행" 섹션을 가이드 링크 + 4단계 요약으로 교체 |
| `CLAUDE.md` | 커밋 컨벤션에 `contributions:` 반영 |
| `.github/ISSUE_TEMPLATE/*` 2종 | 하단에 가이드 링크 추가 |
| `.github/PULL_REQUEST_TEMPLATE.md` | 한 줄짜리 템플릿을 Summary·관련 이슈 구조로 확장 (기여 기록 가이드 링크 주석 포함) |

## Test

- [x] `npm test` — 122개 전부 통과
- [x] `npm run lint` / `npm run validate:data` / `npm run lint:md` 통과
- [x] `npm run build` — 빌드 산출물에 `/docs/contribution-record/` 페이지 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


