### PR TITLE
docs: Update issue workflow for mentee triage access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,15 @@ Chromium Gerrit에 업로드하는 패치는 이 규칙이 아니라 아래 [com
 - 새로운 기능이나 버그 수정을 제안하고 싶다면 새 이슈를 생성해 주세요. 적절한 이슈 템플릿을 골라 작성하세요.
 - 기존 이슈 중 작업하고 싶은 것이 있다면 댓글을 남겨 작업 의사를 밝혀주세요.
 
-### 3주차 진행 전 할 것
+### Contribution 진행 전 할 것
 
 1. CLA 동의하기 https://cla.developers.google.com/about/google-individual
 2. 모든 건 실명으로 (영어이름 성)
 3. https://chromium-review.googlesource.com 가입하기
 4. git config user.name "실명 영어로"
 5. git config.user.email "email 주소" (gerrit 가입 이메일과 동일해야 함)
-6. 하고 싶은 이슈에 댓글 달기
-7. 멘토가 이슈를 assign 하면 작업 진행
+6. 하고 싶은 이슈의 Assignees 에 본인을 직접 지정 (self-assign, 이슈당 1인 선착순)
+7. 이슈 assign 후 작업 진행
 8. Checklist 내용을 진행하면서 작업한 내용을 댓글로 달기
 9. 진행 상태에 따라 이슈의 Status 를 `멘티 작업 진행 중` -> `멘토 리뷰 중` -> `gerrit 리뷰 중` -> `반영 완료` 로 변경
 

--- a/data/docs/contribution-record.md
+++ b/data/docs/contribution-record.md
@@ -114,10 +114,14 @@ git push origin 250801-merged-6520751
 
 ## 5. GitHub 이슈·프로젝트 보드
 
+- 실습 이슈는 오른쪽 **Assignees**에 본인을 직접 지정(self-assign)해
+  시작합니다 (이슈당 1인, 선착순).
 - 담당한 GitHub 이슈에 **Gerrit CL 링크**와 **기여 기록 PR 링크**를 코멘트로
   남기세요.
-- 프로젝트 보드(2026 Chromium Issues)의 Status 이동과 이슈 close는 멘토가
-  처리합니다. 직접 옮기지 않아도 됩니다.
+- 진행 상태에 따라 프로젝트 보드(2026 Chromium Issues)의 **Status**를 직접
+  변경하세요: `멘티 작업 진행 중` → `멘토 리뷰 중` → `gerrit 리뷰 중` →
+  `반영 완료`.
+- 이슈 close는 멘토가 처리합니다.
 
 ## 자주 하는 실수
 


### PR DESCRIPTION
## Summary

멘티에게 Triage 권한이 부여됨에 따라, 이슈 워크플로우 안내를 "코멘트 → 멘토 지정" 방식에서 "직접 self-assign · 직접 Status 변경" 방식으로 갱신합니다.

- **가이드 §5**: 실습 이슈 self-assign 직접 지정, 프로젝트 보드 Status 직접 변경 안내로 재작성
- **CONTRIBUTING.md**: 섹션명 일반화("3주차 진행 전" → "Contribution 진행 전") + 6~7번을 self-assign 문구로 변경
- **이슈 close**: 멘토 담당 유지

## Background

- **Triage 권한**: 멘티 전원에게 contributions repo Triage 권한 부여 → 이슈 self-assign 직접 수행 가능
- **보드 권한**: org 프로젝트 "2026 Chromium Issues"의 base role이 Write → 멘티가 보드 Status 직접 변경 가능 확인
- **문서 정합성**: 기존 "코멘트 남기고 멘토가 assign" 흐름이 실제 권한과 불일치 → 가이드·CONTRIBUTING 갱신
- **실습 이슈**: GitHub 실습 이슈 41건(#188, #190~#229)의 본문도 같은 문구로 이미 일괄 수정 완료
- **섹션명 변경**: 특정 주차에 묶이지 않도록 일반화. 안내 이슈 #190의 앵커 링크도 새 앵커로 갱신 완료

## Changes

| 파일 | 변경 |
| --- | --- |
| `data/docs/contribution-record.md` | §5 재작성: self-assign 직접 지정(이슈당 1인 선착순), Status 직접 변경(`멘티 작업 진행 중` → `멘토 리뷰 중` → `gerrit 리뷰 중` → `반영 완료`), 이슈 close만 멘토 담당 |
| `CONTRIBUTING.md` | 섹션명 "Contribution 진행 전 할 것"으로 변경, 6~7번을 self-assign · assign 후 작업 진행으로 갱신 |

## 관련 이슈

#188, #190~#229 (실습 이슈 본문 일괄 수정 완료), #190 (앵커 링크 갱신 완료)
