### PR TITLE
docs: Add branch creation step to contribution checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ Chromium Gerrit에 업로드하는 패치는 이 규칙이 아니라 아래 [com
 
 #### Checklist
 
+- [ ] 작업 브랜치 생성 `git checkout -b <브랜치명> origin/main` (main 브랜치에서 직접 커밋 금지, 브랜치 하나가 CL 하나에 대응)
 - [ ] src/AUTHORS 파일에 이름, 이메일 추가 (알파벳 순, gerrit, git 이메일과 동일)
 - [ ] 마크다운 문서 로컬에서 확인해보기 `./tools/md_browser/md_browser.py` 실행 -> http://localhost:8080 에서 확인
 - [ ] 이슈에 써 있는 부분 외에 추가로 깨진 부분 있는지 확인해보기 (다른 링크도 눌러보기)


### PR DESCRIPTION
## Summary

- **체크리스트 보강**: CONTRIBUTING.md "Checklist" 첫 항목으로 작업 브랜치 생성 단계 추가
- **내용**: `git checkout -b <브랜치명> origin/main` — main 직접 커밋 금지, 브랜치 하나가 CL 하나에 대응
- **효과**: 멘티가 main에서 바로 커밋하는 실수 예방

## Background

- **점검 계기**: 2주차 실습(멘티 첫 Chromium CL)을 앞두고 체크리스트 점검
- **문제**: 체크리스트가 "commit 만들기 → git cl upload"로 시작해 chromium 작업 브랜치 생성 단계가 누락
- **간극**: 사이트의 "첫 CL 올리기" 문서에는 브랜치 생성이 있으나, 실습 이슈(#190)가 링크하는 체크리스트에는 없음
- **참고**: #230(draft)도 CONTRIBUTING.md의 다른 부분(섹션명·6~7번)을 수정 중 — 겹치는 라인 없어 충돌 없음

## 관련 이슈

#190
