### PR TITLE
contributions: Add 8146339

### DIFF
--- a/data/contributions/8146339.md
+++ b/data/contributions/8146339.md
@@ -1,0 +1,129 @@
+---
+
+title: "Fix BigBuffer link in Mojo style guide"
+
+date: 2026-07-28
+
+author: TinyGeek # github.com/TinyGeek
+
+contribution_url: https://crrev.com/c/8146339
+
+labels: ["docs", "mojo"]
+
+status: merged
+
+--------------
+
+Chromium의 Mojo 스타일 가이드에서 잘못 연결되던 `BigBuffer` 문서 링크를 저장소 루트 기준의 경로로 수정했습니다.
+
+## 문제 설명
+
+`docs/security/mojo.md`의 `BigBuffer` 링크가 다음과 같은 상대 경로로 작성되어 있었습니다.
+
+```markdown
+
+[BigBuffer](mojo/public/mojom/base/big_buffer.mojom)
+
+```
+
+Gitiles는 이 경로를 현재 문서가 위치한 `docs/security` 디렉터리를 기준으로 해석합니다. 따라서 실제로는 다음과 같은 존재하지 않는 경로를 가리키게 됩니다.
+
+```text
+
+docs/security/mojo/public/mojom/base/big_buffer.mojom
+
+```
+
+이로 인해 Mojo 스타일 가이드에서 `BigBuffer` 링크를 클릭하면 실제 소스 파일로 이동할 수 없었습니다.
+
+* 상대 경로가 현재 문서의 디렉터리를 기준으로 해석됨
+
+* 존재하지 않는 경로로 연결되어 링크가 정상적으로 동작하지 않음
+
+* 문서를 읽는 사용자가 `BigBuffer` 정의를 바로 확인할 수 없음
+
+## 해결 내용
+
+링크 경로 앞에 `/`를 추가하여 Gitiles가 Chromium 저장소의 루트 디렉터리를 기준으로 경로를 해석하도록 수정했습니다.
+
+```diff
+
+-[BigBuffer](mojo/public/mojom/base/big_buffer.mojom) uses shared memory to make
+
++[BigBuffer](/mojo/public/mojom/base/big_buffer.mojom) uses shared memory to make
+
+```
+
+변경 후 링크는 저장소 루트의 다음 파일을 올바르게 가리킵니다.
+
+```text
+
+mojo/public/mojom/base/big_buffer.mojom
+
+```
+
+또한 Chromium 첫 기여 과정에서 기여자 정보를 등록하기 위해 `AUTHORS` 파일에 이름과 이메일을 추가했습니다.
+
+주요 변경 파일은 다음과 같습니다.
+
+1. `docs/security/mojo.md`
+
+   * `BigBuffer` 링크를 저장소 루트 기준 경로로 변경
+
+2. `AUTHORS`
+
+   * 기여자 정보 추가
+
+기능 코드에는 영향을 주지 않고, 잘못된 문서 링크만 최소 범위로 수정했습니다.
+
+## 테스트 방법
+
+문서 링크 수정이므로 별도의 단위 테스트나 성능 테스트는 필요하지 않았으며, 다음 방법으로 변경 사항을 검증했습니다.
+
+1. **Gitiles 링크 확인**
+
+   * 수정된 Mojo 스타일 가이드 페이지에서 `BigBuffer` 링크를 클릭
+
+   * `mojo/public/mojom/base/big_buffer.mojom` 파일로 정상 이동하는지 확인
+
+2. **파일 권한 검사**
+
+```bash
+
+python3 tools/checkperms/checkperms.py
+
+```
+
+검사 결과 `SUCCESS`를 확인했습니다.
+
+3. **Chromium Presubmit 검사**
+
+   * `git cl upload` 과정에서 Chromium presubmit 검사를 수행
+
+   * 관련 검사가 정상적으로 통과함을 확인
+
+4. **Gerrit 리뷰 및 CQ 확인**
+
+   * Gerrit 코드 리뷰를 통과
+
+   * Chromium LUCI CQ를 통해 `main` 브랜치에 정상 반영됨
+
+문서 경로만 변경한 작업이므로 Chromium 전체 빌드 및 성능 테스트는 수행하지 않았습니다.
+
+## 배운 점
+
+* Gitiles의 상대 경로는 현재 Markdown 파일이 위치한 디렉터리를 기준으로 해석된다는 점을 배웠습니다.
+
+* 경로 앞에 `/`를 추가하면 저장소 루트 기준의 링크를 작성할 수 있다는 것을 확인했습니다.
+
+* Chromium의 `AUTHORS`, `Change-Id`, Gerrit 리뷰, Presubmit, Commit Queue로 이어지는 기여 절차를 경험했습니다.
+
+* 작은 문서 수정이라도 실제 링크 동작과 변경 범위를 직접 검증하는 과정이 중요하다는 것을 배웠습니다.
+
+* 대규모 오픈소스에서는 문제를 해결하는 것뿐만 아니라, 변경 범위를 최소화하고 리뷰어가 의도를 빠르게 이해할 수 있도록 커밋 메시지를 작성하는 것도 중요하다는 점을 배웠습니다.
+
+## 참고 자료
+
+* [Bug link](https://crbug.com/538651940)
+
+* [CL link](https://crrev.com/c/8146339)

--- a/data/contributions/8146339.md
+++ b/data/contributions/8146339.md
@@ -1,18 +1,11 @@
 ---
-
 title: "Fix BigBuffer link in Mojo style guide"
-
 date: 2026-07-28
-
-author: TinyGeek # github.com/TinyGeek
-
+author: zbnerd # github.com/zbnerd
 contribution_url: https://crrev.com/c/8146339
-
 labels: ["docs", "mojo"]
-
 status: merged
-
---------------
+---
 
 Chromium의 Mojo 스타일 가이드에서 잘못 연결되던 `BigBuffer` 문서 링크를 저장소 루트 기준의 경로로 수정했습니다.
 


### PR DESCRIPTION
## Summary

docs/security/mojo.md의 mojo/public/mojom/base/big_buffer.mojom를 /mojo/public/mojom/base/big_buffer.mojom로 변경하였습니다.
mojo/public/mojom/base/big_buffer.mojom 가 docs/security/ 의 상대경로를 참조하여 404가 발생하는 상황이었고 이를 절대경로 /mojo/public/mojom/base/big_buffer.mojom로 참조하도록 fix 하였습니다.


## Link

- [Bug link](https://crbug.com/538651940)
- [CL link](https://crrev.com/c/8146339)

## 관련 이슈
#190 #222