### PR TITLE
contributions: Add 8146220

### DIFF
--- a/data/contributions/8146220.md
+++ b/data/contributions/8146220.md
@@ -1,0 +1,57 @@
+---
+title: "Docs: Fix broken Siso tips links in build instructions"
+date: 2026-07-25
+author: jsy8315
+contribution_url: https://crrev.com/c/8146220
+labels: ["docs", "fix"]
+status: merged
+---
+
+Chromium 문서의 macOS·Windows 빌드 안내에서 Siso tips 문서로 가는 링크가 깨져 있던 문제를 수정했습니다.
+
+## 문제 설명
+
+`docs/mac_build_instructions.md`와 `docs/windows_build_instructions.md`에서 Siso tips 문서를 가리키는 링크가 동작하지 않았습니다.
+
+```markdown
+See [Siso tips](../siso_tips.md) too.
+```
+
+- 두 문서는 모두 `docs/` 하위에 있고, 링크 대상인 `siso_tips.md`도 같은 디렉터리에 있음
+- `../` 때문에 링크가 `docs/`보다 한 단계 위인 저장소 루트를 가리킴
+- Gitiles에서 클릭하면 `chromium/src/+/main/siso_tips.md`로 이동해 `NOT_FOUND` 응답
+- 대상 파일 자체는 존재하며, 상대 경로의 깊이만 잘못된 상태
+
+## 해결 내용
+
+1. 링크가 실제로 해석되는 경로와 대상 파일의 위치를 각각 확인해 원인을 경로 깊이 오류로 판정
+2. 두 파일에서 `../` 접두사만 제거
+
+```markdown
+See [Siso tips](siso_tips.md) too.
+```
+
+3. `docs/` 전체에 동일한 유형의 링크가 더 있는지 확인해 수정 범위를 2건으로 한정
+4. 첫 기여이므로 `AUTHORS`에 이름과 이메일을 알파벳순으로 추가하고 같은 커밋에 포함
+
+## 테스트 방법
+
+1. `vpython3 tools/md_browser/md_browser.py`로 로컬 렌더링 서버를 실행
+2. `http://localhost:8080/docs/mac_build_instructions.md`, `http://localhost:8080/docs/windows_build_instructions.md`에서 링크가 `docs/siso_tips.md`로 이동하는지 확인
+3. 수정 전후의 Gitiles 경로를 비교해 `NOT_FOUND`가 해소되는지 확인
+4. `git cl upload` 시 자동 실행되는 presubmit 통과 확인
+
+## 배운 점
+
+- 마크다운 상대 경로는 문서가 위치한 디렉터리를 기준으로 해석되므로, 같은 디렉터리의 파일에는 `../`를 붙이면 안 됩니다.
+- Chromium 도구는 스크립트 첫 줄의 shebang이 실행 방법을 지정합니다. `md_browser.py`는 `#!/usr/bin/env vpython3`이며, `python3`로 실행하면 의존성을 찾지 못해 실패합니다.
+- Gerrit 인증은 `git cl creds-check`로 설정만 되고, 실제 로그인은 `git credential-luci login`을 따로 실행해야 합니다.
+- 리뷰어는 해당 파일의 수정 이력에서 반복적으로 등장하는 리뷰어를 찾아 지정하는 것이 효과적이었습니다.
+- 기여 전반 과정을 빠르게 경험할 수 있어 좋았습니다. 
+
+## 참고 자료
+
+- [Chromium Issue 538651940](https://issues.chromium.org/issues/538651940)
+- [docs/siso_tips.md](https://chromium.googlesource.com/chromium/src/+/main/docs/siso_tips.md)
+- [docs/mac_build_instructions.md](https://chromium.googlesource.com/chromium/src/+/main/docs/mac_build_instructions.md)
+- [docs/windows_build_instructions.md](https://chromium.googlesource.com/chromium/src/+/main/docs/windows_build_instructions.md)


### PR DESCRIPTION
## Summary

Chromium CL 8146220 기여 기록을 추가합니다. `docs/mac_build_instructions.md`와 `docs/windows_build_instructions.md`에서 `siso_tips.md`를 가리키는 상대 경로가 한 단계 위를 가리켜 깨져 있던 링크를 수정한 건으로, Gerrit에서 merge 완료되어 `status: merged`로 작성했습니다.

## 관련 이슈
- 없음

#이슈번호
- 188 (https://github.com/OSSCA-chromium/contributions/issues/188)