### PR TITLE
contributions: Add 8146340

### DIFF
--- a/data/contributions/8146340.md
+++ b/data/contributions/8146340.md
@@ -1,0 +1,28 @@
+---
+title: "Fix broken links in adding_to_third_party.md"
+date: 2026-07-25
+author: iknoom
+contribution_url: https://crrev.com/c/8146340
+labels: ["docs", "fix"]
+status: merged
+---
+
+`docs/adding_to_third_party.md`에 남아 있던 깨진 상대 링크 두 개를 수정했습니다.
+
+## 문제 설명
+
+- LICENSE 예시가 존재하지 않는 `third_party/libjpeg/LICENSE` 파일을 가리키고 있었습니다.
+- `components_resources.grd` 링크의 경로가 실제 파일명과 달라 문서를 따라가면 파일을 열 수 없었습니다.
+
+## 해결 내용
+
+- LICENSE 예시 링크를 존재하는 `third_party/libpng/LICENSE`로 변경했습니다.
+- `components_resource.grd` 링크를 실제 파일명인 `components_resources.grd`에 맞게 수정했습니다.
+
+## 테스트 방법
+
+- `tools/md_browser/md_browser.py`로 문서를 로컬에서 열어 수정한 링크를 확인했습니다.
+
+## 배운 점
+
+- `tools/md_browser/md_browser.py`를 사용하면 문서를 로컬에서 브라우저 형태로 열어 링크가 올바르게 동작하는지 확인할 수 있다는 점을 배웠습니다.


### PR DESCRIPTION
## Summary

`docs/adding_to_third_party.md`에 남아 있던 깨진 상대 링크 두 개를 수정했습니다.
- LICENSE 예시 링크를 존재하는 `third_party/libpng/LICENSE`로 변경했습니다.
- `components_resource.grd` 링크를 실제 파일명인 `components_resources.grd`에 맞게 수정했습니다.

## 관련 이슈

#216 
