### PR TITLE
chore: Bump Node.js to 22 in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

CI 워크플로우의 Node.js 버전을 20 → 22(active LTS)로 올린다.

- **배경**: #247에서 올린 `markdownlint-cli2` 0.23.2(번들 markdownlint 0.41.1)가 **Node ≥22를 요구** (`engines.node: ">=22"`). 현재 CI는 Node 20이라 `npm ci` 시 `EBADENGINE` 경고 발생 (main 브랜치 deploy run 30464199418 로그에서 확인)
- **변경**: `.github/workflows/deploy.yml`, `.github/workflows/pr-checks.yml` — 각각 `node-version: "20"` → `"22"` 한 줄씩, 총 2줄
- **효과**: 경고 제거 + markdownlint가 Node 22 전용 API를 쓰기 시작해도 `lint:md`가 깨지지 않도록 선제 대응
- **Test**: 워크플로우 설정 변경이므로 이 PR의 pr-checks CI 자체가 Node 22에서 전체 파이프라인(test → lint → validate:data → lint:md → build)을 실행해 검증

## 관련 이슈

없음 (#247 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
