### PR TITLE
contributions: Add 8151902

### DIFF
--- a/data/contributions/8151902.md
+++ b/data/contributions/8151902.md
@@ -1,0 +1,56 @@
+---
+title: "Fix safety guidelines link in Rust FFI documentation"
+date: 2026-07-27
+author: DonghanPark
+contribution_url: https://crrev.com/c/8151902
+labels: ["docs", "fix"]
+status: merged
+---
+
+`docs/rust/ffi.md` 문서에서 안전 가이드라인(`unsafe.md`)을 가리키는 깨진 상대 경로 링크를 수정하였습니다.
+
+## 문제 설명
+
+- `docs/rust/ffi.md` 문서에서 동일 디렉토리에 위치한 안전 가이드라인 문서(`unsafe.md`)를 참조하는 경로가 `docs/rust/unsafe.md#how-to-use-unsafe`로 작성되어 있었습니다.
+- 상대 경로 기준 오류로 인해 실제 브라우저나 문서 뷰어에서는 `docs/rust/docs/rust/unsafe.md` 경로로 잘못 해석되어 404 페이지 오류(깨진 링크)가 발생하고 있었습니다.
+
+## 해결 내용
+
+Chromium Code Search의 git blame 히스토리를 분석하고 대상 문서의 실제 위치를 파악하여 링크를 올바른 상대 경로로 수정하였습니다.
+
+1. 첫 번째 접근 방법
+   * Chromium Code Search의 [git blame 기능](https://source.chromium.org/chromium/chromium/src/+/main:docs/rust/ffi.md;bpv=1;bpt=0)을 활용하여 해당 라인의 히스토리를 파악했습니다.
+   * 분석 결과, 이전 문서 업데이트 과정에서 잘못된 상대 경로 링크가 추가되었음을 확인하였습니다. ([변경 이력 참조](https://source.chromium.org/chromium/chromium/src/+/main:docs/rust/ffi.md;bpv=1;bpt=0;drc=02c8cb9be292399d899e7968fb1150f611dba021;dlc=4dba7416560a7b258ae62fd30ec288101caf481f))
+   * 참조 대상인 `unsafe.md` 파일이 실제 codebase 내에 존재하는지 검색하여 검증하였고, `ffi.md`와 동일한 디렉토리(`docs/rust/`)에 있는 파일을 가리키려 했던 의도임을 파악하였습니다.
+
+2. 구현 세부 사항 및 주요 코드 변경 내용
+
+```diff
+- Make sure you're
+- familiar with our [safety guidelines](docs/rust/unsafe.md#how-to-use-unsafe).
++ familiar with our [safety guidelines](unsafe.md#how-to-use-unsafe).
+```
+
+## 테스트 방법
+
+로컬에서 마크다운 뷰어 서버를 실행하여 수정된 링크가 정상적으로 작동하는지 검증하였습니다.
+
+1. Chromium 내장 도구인 `./tools/md_browser/md_browser.py`를 실행하여 로컬 마크다운 문서 서버를 구동했습니다.
+2. 브라우저로 `docs/rust/ffi.md`에 접속하여 수정된 `safety guidelines` 링크를 클릭했을 때, 대상 문서인 `unsafe.md#how-to-use-unsafe`로 올바르게 이동하며 HTTP GET 요청이 200 OK로 정상 반환되는 것을 확인하였습니다.
+
+## 배운 점
+
+### 기술적 학습
+- **`git cl upload` 시 대량의 object 전송 문제 해결**: shallow clone 상태에서 업로드를 시도할 때 변경 사항은 한 줄뿐임에도 불구하고 50만 건 이상의 object를 탐색하며 업로드가 무한히 지연(멈춤)되는 현상이 있었습니다. 이를 `git fetch --unshallow origin` 명령을 통해 전체 이력을 다 가져온 후 작업 커밋을 rebase하여 업로드를 원활하고 빠르게 마칠 수 있었습니다.
+
+### 프로세스 관련 학습
+- **리뷰어(Reviewer) 선정**: `git blame`으로 파악한 이전 작업자의 이메일을 검색하여 실제로 코드 리뷰를 진행한 이력이 있는지 확인 후 리뷰어로 추가하였습니다.
+
+### 향후 개선 방향
+- **가이드와 멘토링 자료 정독**: 관련 가이드와 멘토링 자료를 꼼꼼히 확인하지 못해 리뷰어에 멘토님을 초기에 지정하지 않았습니다. 다음부터는 사전에 가이드와 멘토링 자료를 확실히 확인하고 멘토링 시간에도 더 집중해야겠다고 다짐했습니다.
+
+## 참고 자료
+
+- [컨트리뷰션 기록 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)
+- [첫 CL 작성 가이드](https://ossca-chromium.github.io/contributions/docs/first-cl/)
+- [CONTRIBUTING.md 가이드](https://github.com/OSSCA-chromium/contributions/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

* Rust FFI 문서(`docs/rust/ffi.md`) 내 안전 가이드라인 링크의 404 경로 오류를 수정하였습니다.
* 해당 기여([CL #8151902](http://crrev.com/c/8151902))의 로컬 테스트 및 `git cl upload` 트러블슈팅 과정을 정리한 기여 기록 문서(`data/contributions/8151902.md`)를 추가합니다.

## 관련 이슈

#212