### PR TITLE
contributions: Add 8147039

### DIFF
--- a/data/contributions/8147039.md
+++ b/data/contributions/8147039.md
@@ -1,0 +1,55 @@
+---
+title: Fix broken link to ui/gfx/native_widget_types.h
+date: 2026-07-26
+author: parkhojeong
+contribution_url: https://crrev.com/c/8147039
+labels: ["docs", "fix"]
+status: merged
+---
+
+`ui/gfx/native_widget_types.h`를 가리키는 깨진 링크와 타입 네임스페이스
+오타를 수정했습니다.
+
+## 문제 설명
+
+`ui/gfx/native_widget_types.h`는
+[CL 6938086](https://crrev.com/c/6938086)에서
+`ui/gfx/native_ui_types.h`로 변경되었지만,
+`docs/ui/learn/glossary.md`와 `docs/mac/mixing_cpp_and_objc.md`에는
+이전 경로가 남아 있었습니다.
+
+또한 `docs/mac/mixing_cpp_and_objc.md`에는 `ui::NativeView`로 잘못
+표기되어 있었습니다.
+
+## 해결 내용
+
+- 두 문서에서 헤더 경로를 `ui/gfx/native_ui_types.h`로 변경했습니다.
+- `ui::NativeView`를 실제 네임스페이스인 `gfx::NativeView`로 수정했습니다.
+
+`docs/ui/learn/glossary.md`
+
+```diff
+-[`AcceleratedWidget`](/ui/gfx/native_widget_types.h) on Windows.
++[`AcceleratedWidget`](/ui/gfx/native_ui_types.h) on Windows.
+```
+
+`docs/mac/mixing_cpp_and_objc.md`
+
+```diff
+-`ui/gfx/native_widget_types.h`'s `ui::NativeView`,
++`ui/gfx/native_ui_types.h`'s `gfx::NativeView`,
+```
+
+## 테스트 방법
+
+Gitiles에서 변경된 링크가 정상적으로 열리는 것을 확인했습니다.
+
+## 배운 점
+
+- 링크뿐 아니라 주변 내용도 함께 확인해야 한다는 점을 배웠습니다.
+
+## 참고 자료
+
+- [헤더 이름 변경 CL 6938086](https://crrev.com/c/6938086)
+- [Chromium Bug 538651940](https://crbug.com/538651940)
+- [작업 이슈 #202](https://github.com/OSSCA-chromium/contributions/issues/202)


### PR DESCRIPTION
## Summary

<!-- 무엇을 왜 바꿨는지 1~3줄로 적어주세요 -->
ui/gfx/native_widget_types.h 를 가리키는 깨진 링크를 수정하고 타입 네임스페이스 오타를 수정했습니다.

## 관련 이슈

<!-- 관련 GitHub 이슈 번호 (예: #188). 없으면 "없음" -->
<!-- 기여 기록 PR은 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 참고하세요 -->
#202 
