### PR TITLE
fix: Prevent IN REVIEW badge from wrapping in narrow cards

### DIFF
--- a/__tests__/components/StatusBadge.test.tsx
+++ b/__tests__/components/StatusBadge.test.tsx
@@ -10,3 +10,9 @@ test('status가 없으면 아무것도 렌더링하지 않는다', () => {
   const { container } = render(<StatusBadge />);
   expect(container).toBeEmptyDOMElement();
 });
+
+// 'IN REVIEW'는 공백이 있는 두 단어라 좁은 카드에서 줄바꿈되면 배지가 깨진다.
+test('in review 배지는 줄바꿈되지 않는다', () => {
+  render(<StatusBadge status="in review" />);
+  expect(screen.getByText('IN REVIEW')).toHaveClass('whitespace-nowrap');
+});

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -10,7 +10,9 @@ export default function StatusBadge({ status }: { status?: ContributionStatus })
   if (!status || !MAP[status]) return null;
   const { label, cls } = MAP[status];
   return (
-    <span className={`px-2 py-1 text-xs rounded-full font-medium ${cls}`}>
+    <span
+      className={`px-2 py-1 text-xs rounded-full font-medium whitespace-nowrap shrink-0 ${cls}`}
+    >
       {label}
     </span>
   );


### PR DESCRIPTION
## Summary

- **문제**: 배포 사이트 홈·목록 카드에서 "in review" 상태 배지만 레이아웃 깨짐(줄바꿈 동반)
- **원인**: 두 단어 "IN REVIEW" 라벨이 좁은 카드에서 줄바꿈 → pill 배지 찌그러짐
- **수정**: 배지에 줄바꿈 방지 처리 추가 + 긴 제목이 배지를 눌러 찌그러뜨리지 못하게 고정

## 관련 이슈

없음

## Background

- **증상**: 홈과 /patches 카드 목록에서 "in review" 배지가 "IN" / "REVIEW"로 쪼개져 배지 모양이 깨짐
- **정상 케이스**: merged / draft 배지는 멀쩡 → 한 단어라 줄바꿈 여지 없음
- **트리거 조건**: 카드 제목이 길어 flex 행이 좁아질 때, 두 단어 "IN REVIEW"만 줄바꿈되어 깨짐

## Changes

- **줄바꿈 방지**: 배지 라벨을 한 줄에 고정 (whitespace-nowrap)
- **배지 크기 보존**: 긴 제목이 배지를 압축하지 못하도록 고정 (shrink-0), 제목은 기존 line-clamp로 잘림 처리
- **회귀 테스트**: "in review" 배지가 줄바꿈되지 않음을 검증하는 테스트 추가

## Test

- [x] `npm test` — 123 passed
- [x] `npm run lint` — 통과
