### PR TITLE
chore: Add 2026 label and auto-assign author for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/sub-issue-등록.md
+++ b/.github/ISSUE_TEMPLATE/sub-issue-등록.md
@@ -2,7 +2,7 @@
 name: Sub-Issue 등록
 about: '특정 이슈에 대한 sub-issue 를 등록할 때 사용합니다. '
 title: "[주제] 폴더명"
-labels: chromium-issues
+labels: 2026, chromium-issues
 assignees: ''
 
 ---

--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,26 @@
+name: Auto-assign issue author
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-author:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'chromium-issues') ||
+      contains(github.event.issue.labels.*.name, 'self-issues') ||
+      contains(github.event.issue.labels.*.name, 'exercise')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.issue.user.login],
+            });


### PR DESCRIPTION
## Summary

이슈 템플릿 운영 개선 2건:

- **`2026` label 보완**: 다른 이슈 템플릿에는 이미 있는 `2026` label이 Sub-Issue 템플릿에만 누락되어 있어 추가 (`labels: 2026, chromium-issues`)
- **작성자 자동 assign**: 이슈 등록자가 곧 작업자인 운영 구조라, 이슈가 열릴 때 작성자를 assignee로 자동 지정하는 workflow 신설 (`auto-assign-issue.yml`)

### 동작 방식

- **트리거**: 이슈 open 시 `chromium-issues` / `self-issues` / `exercise` label 중 하나라도 있으면 `actions/github-script`로 작성자를 assignee로 추가
- **제외 대상**: Q&A(`2026` label만)와 gh-pages 템플릿은 자동 assign 대상 아님
- **workflow가 필요한 이유**: 템플릿 frontmatter의 `assignees`는 고정 username만 지원 — 실제 작성자를 지정하려면 workflow 필요

## 관련 이슈

없음
