### PR TITLE
contributions: Add 8228946

### DIFF
--- a/data/contributions/8228946.md
+++ b/data/contributions/8228946.md
@@ -1,0 +1,80 @@
+---
+title: "base: Test no event for directory touch on Windows"
+date: 2026-08-15
+author: parkhojeong
+contribution_url: https://crrev.com/c/8228946
+labels: ["base", "testing"]
+status: merged
+---
+
+Windows에서 재귀적으로 감시 중인 디렉터리를 touch해도
+`FilePathWatcher` 이벤트가 전달되지 않는 동작을 테스트로 검증했습니다.
+
+## 문제 설명
+
+`FilePathWatcherTest.RecursiveWatch`는 Windows에서 디렉터리를 touch하는 코드가
+실행되지 않아, Windows의 `FilePathWatcher` 동작을 검증하지 못하고 있었습니다.
+
+Windows의 `FilePathWatcher`는 디렉터리에 대한 `FILE_ACTION_MODIFIED` 알림을
+필터링하므로, 감시 중인 디렉터리를 touch해도 콜백 이벤트가 발생하지 않아야
+합니다.
+
+## 해결 내용
+
+Windows에서도 감시 중인 디렉터리에 `TouchFile()`을 호출하도록 테스트를
+변경했습니다.
+
+Windows에서는 기대 이벤트를 추가하지 않은 상태로 이벤트 루프를 진행하여,
+새로운 콜백 이벤트가 발생하지 않는 것을 검증했습니다.
+
+```diff
+ // Mac and Win don't generate events for Touch.
+-// TODO(crbug.com/40263777): Add explicit expectations for Win.
+ // Android TouchFile returns false.
+-#if !(BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID))
++#if !BUILDFLAG(IS_ANDROID)
+   // Touch "$dir".
+   Time access_time;
+   ASSERT_TRUE(Time::FromString("Wed, 16 Nov 1994, 00:00:00", &access_time));
+   ASSERT_TRUE(TouchFile(dir, access_time, access_time));
+-#if !BUILDFLAG(IS_APPLE)
++#if !(BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_WIN))
+   // TODO(crbug.com/40263766): Investigate why we're getting two events
+   // here from inotify.
+   event_expecter.AddExpectedEventForPath(dir);
+   event_expecter.AddExpectedEventForPath(dir);
+-#endif  // !BUILDFLAG(IS_APPLE)
++#endif  // !(BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_WIN))
+   delegate.RunUntilEventsMatch(event_expecter);
+   // TODO(crbug.com/40263777): Add a test touching `subdir`.
+-#endif  // !(BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID))
++#endif  // !BUILDFLAG(IS_ANDROID)
+```
+
+## 테스트 방법
+
+Windows에서 다음 테스트를 대상으로 검증했습니다.
+
+```bash
+base_unittests --gtest_filter=FilePathWatcherTest.RecursiveWatch
+```
+
+Gerrit LUCI dry-run과 제출 전 전체 CQ가 통과했으며, CL은 Chromium main에
+병합되었습니다.
+
+## 배운 점
+
+- Windows에서 파일 변경 알림이 발생하더라도 `FilePathWatcher`가 디렉터리에 대한
+  `FILE_ACTION_MODIFIED` 알림을 필터링하여 이벤트가 전달되지 않는다는 점을
+  배웠습니다.
+- 비동기 이벤트가 발생하지 않아야 하는 동작은 이벤트 루프를 잠시 실행해 알림이
+  처리될 시간을 준 뒤, 기대 이벤트 목록과 실제 수신 이벤트 목록이 일치하는지
+  확인하여 테스트할 수 있음을 알게 되었습니다.
+
+## 참고 자료
+
+- [작업 이슈 #300](https://github.com/OSSCA-chromium/contributions/issues/300)
+- [Gerrit CL 8228946](https://crrev.com/c/8228946)
+- [Windows FilePathWatcher 필터링 로직](https://source.chromium.org/chromium/chromium/src/+/main:base/files/file_path_watcher_win.cc)
+- [Apple 관련 선행 CL 8042283](https://crrev.com/c/8042283)
+- [Chromium Issue 40263777](https://crbug.com/40263777)


### PR DESCRIPTION
## Summary

`base/files/file_path_watcher_unittest.cc`의 기존 `FilePathWatcherTest.RecursiveWatch`에서 
Windows에서 디렉터리 touch 동작을 검증하도록 수정했습니다 

## 관련 이슈

Closes #300
<!-- 관련 GitHub 이슈 번호 (예: #188). 없으면 "없음" -->
<!-- 기여 기록 PR은 [기여 기록하기 가이드](https://ossca-chromium.github.io/contributions/docs/contribution-record/)를 참고하세요 -->
