### PR TITLE
contributions: Add 8255452

### DIFF
--- a/data/contributions/8255452.md
+++ b/data/contributions/8255452.md
@@ -1,0 +1,104 @@
+---
+title: "Migrate crypto/sha2 to crypto/hash in webui/certificate_manager"
+date: 2026-08-13
+author: jsy8315
+contribution_url: https://crrev.com/c/8255452
+labels: ["crypto", "refactor"]
+status: merged
+---
+
+`//crypto` 의 신규 API 마이그레이션 작업의 일부로, `chrome/browser/ui/webui/certificate_manager` 디렉터리에서 사용하던 구 API `crypto/sha2.h` 를 신 API `crypto/hash.h` 로 교체했습니다.
+
+## 문제 설명
+
+Chromium 은 `//crypto` 의 API 를 기능별 하위 네임스페이스로 재정리하는 작업을 진행 중이며, SHA-256 해시 API 도 그 대상입니다.
+
+```cpp
+// 구 API — crypto/sha2.h
+namespace crypto {
+  static const size_t kSHA256Length = 32;
+  CRYPTO_EXPORT std::array<uint8_t, kSHA256Length> SHA256Hash(base::span<const uint8_t> input);
+}
+
+// 신 API — crypto/hash.h
+namespace crypto::hash {
+  inline constexpr size_t kSha256Size = 32;
+  CRYPTO_EXPORT std::array<uint8_t, kSha256Size> Sha256(base::span<const uint8_t> data);
+}
+```
+
+- `crypto/sha2.h` 를 include 하는 파일이 저장소 전체에 175개 존재
+- 그중 `chrome/browser/ui/webui/certificate_manager` 에 5개 파일이 해당
+- 신 API 는 `crypto::hash` 라는 하위 네임스페이스로 분리되어 있어, include 경로와 호출부를 함께 수정해야 함
+
+## 해결 내용
+
+### 1. 작업 범위 선정
+
+하나의 CL 은 리뷰어 한 명에게 전부 승인받을 수 있는 범위여야 하므로, OWNERS 가 공통인 디렉터리 단위로 묶었습니다.
+
+```
+chrome/browser/ui/webui/certificate_manager/OWNERS
+  └─ file://net/cert/OWNERS  →  davidben@chromium.org, mattm@chromium.org
+```
+
+5개 파일이 모두 한 디렉터리에 있어 리뷰어 한 명의 승인으로 처리 가능한 구성입니다.
+
+### 2. API 교체
+
+| 기존 | 변경 |
+|---|---|
+| `crypto/sha2.h` | `crypto/hash.h` |
+| `crypto::SHA256Hash(x)` | `crypto::hash::Sha256(x)` |
+| `crypto::kSHA256Length` | `crypto::hash::kSha256Size` |
+
+반환 타입이 양쪽 모두 `std::array<uint8_t, 32>` 로 동일하여 호출부의 타입 변경 없이 교체할 수 있었습니다.
+
+```cpp
+// 변경 전
+std::array<uint8_t, crypto::kSHA256Length> hash;
+if (hash == crypto::SHA256Hash(cert)) {
+
+// 변경 후
+std::array<uint8_t, crypto::hash::kSha256Size> hash;
+if (hash == crypto::hash::Sha256(cert)) {
+```
+
+### 3. 미사용 include 제거
+
+`client_cert_sources.cc` 는 `crypto/sha2.h` 를 include 하고 있었으나 `crypto::` API 를 전혀 사용하지 않아 include 만 제거했습니다.
+
+파일 안에 `sha256_hex_hash` 변수명과 `net::SHA256HashValue` 타입이 있어 사용 중인 것처럼 보이지만, 이들은 `net` 네임스페이스의 별개 타입입니다.
+
+최종 변경 규모는 5개 파일, 14줄 추가 15줄 삭제입니다.
+
+## 테스트 방법
+
+```bash
+autoninja -C out/Default chrome
+autoninja -C out/Default unit_tests
+```
+
+- 수정한 4개 파일이 `CXX` 단계에서 정상 컴파일되는 것을 확인했습니다.
+- `git cl format` 실행 시 변경 사항이 없어 스타일 규약을 준수함을 확인했습니다.
+- 구 API 잔존 여부를 확인했습니다.
+
+  ```bash
+  grep -rn 'crypto/sha2\|crypto::SHA256Hash\|crypto::kSHA256Length' \
+    chrome/browser/ui/webui/certificate_manager/
+  ```
+
+`client_cert_sources_writable_unittest.cc` 는 `BUILD.gn` 에서 `use_nss_certs`(Linux/ChromeOS) 조건부로 빌드되어 macOS 로컬에서는 컴파일 대상이 아니었습니다. 이 부분은 CQ dry run 에서 Linux 봇을 통해 검증했습니다.
+
+## 배운 점
+
+- **OWNERS 는 위치가 아니라 전문성 기준으로 정해집니다.** `certificate_manager` 의 OWNERS 가 `file://net/cert/OWNERS` 를 가리키는 것은 인증서를 다루는 UI 라 인증서 도메인 지식이 필요하기 때문입니다. `file://` 는 부모 디렉터리를 뜻하는 것이 아니라 다른 파일의 명단을 참조하는 링크입니다.
+- **부모 디렉터리의 OWNERS 도 함께 적용되어 승인 가능한 사람이 합집합이 됩니다.** 이번 CL 은 `chrome/browser/ui/OWNERS` 에 등재된 리뷰어의 승인으로 요건이 충족되었습니다.
+- **`BUILD.gn` 의 조건부 빌드를 확인해야 합니다.** 파일이 존재한다고 해서 현재 플랫폼에서 컴파일되는 것은 아니며, `gn args out/Default --list=<플래그>` 로 확인할 수 있습니다.
+- **`git cl presubmit` 과 `git cl upload` 의 검사 세트가 다릅니다.** 같은 항목이 전자에서는 ERROR, 후자에서는 Warning 으로 분류되는 경우가 있습니다.
+
+## 참고 자료
+
+- [//crypto: migrate callers to new APIs](https://issues.chromium.org/issues/372283556)
+- [crypto/hash.h](https://source.chromium.org/chromium/chromium/src/+/main:crypto/hash.h)
+- [chrome/browser/ui/webui/certificate_manager](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/webui/certificate_manager/)


### PR DESCRIPTION
## Summary

`chrome/browser/ui/webui/certificate_manager` 의 `crypto/sha2.h` 를 `crypto/hash.h` 로
마이그레이션한 CL([crrev.com/c/8255452](https://crrev.com/c/8255452))이 머지되어 기여 기록을 추가합니다.

## 관련 이슈

#302
