### PR TITLE
contributions: Fix invalid author in 8146299

### DIFF
--- a/data/contributions/8146299.md
+++ b/data/contributions/8146299.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix schemeless crbug link in severity-guidelines.md"
 date: 2026-07-25
-author: github.com/mirusu400 # github.com/GitHubId
+author: mirusu400
 contribution_url: https://crrev.com/c/8146299
 labels: ["docs"] # directory name and detail
 status: merged # in review, merged 중 하나 선택


### PR DESCRIPTION
## Summary

- **문제**: `data/contributions/8146299.md`의 author가 템플릿 안내 문구(`github.com/mirusu400 # github.com/GitHubId`) 그대로 기록되어 `isValidGithubUsername` 검증에 걸림 — contributor 프로필 링크·개인 페이지가 생성되지 않음
- **수정**: author를 GitHub username 표기(`mirusu400`)로 교정
- **검증**: `npm run validate:data` 통과 확인

## 관련 이슈

없음
