### PR TITLE
contributions: Add 8221527

### DIFF
--- a/data/contributions/8260551.md
+++ b/data/contributions/8260551.md
@@ -1,0 +1,58 @@
+---
+title: Remove non-standard RTCConfiguration.iceTransports alias
+date: 2026-08-21
+author: Yelihi
+contribution_url: https://crrev.com/c/8260551
+labels: ["blink", "webrtc", "interop-2026"]
+status: merged
+---
+
+Blink의 `RTCConfiguration.iceTransports` 비표준 alias를 기본 동작에서 제거하고, Interop 2026 WPT가 기대하는 표준 동작에 맞춘 변경입니다.
+
+## 문제 설명
+
+WebRTC 표준은 `RTCConfiguration`에 `iceTransportPolicy`만 정의하지만, Chromium Blink는 M56부터 `iceTransports`를 alias로 받아주고 있었습니다.
+
+이 때문에 `{ iceTransports: ... }`가 알 수 없는 dictionary member로 무시되지 않고 실제 ICE policy에 반영되거나, 잘못된 enum 값에서 `TypeError`를 던졌습니다. 그 결과 Interop 2026의 `RTCConfiguration-iceTransportPolicy` WPT 기대값과 맞지 않았습니다.
+
+## 해결 내용
+
+1. `rtc_configuration.idl`에서 비표준 `iceTransports` 멤버를 기본 노출 대상에서 제거했습니다.
+2. 리뷰 의견에 따라 alias를 완전히 삭제하지 않고 `RTCConfigurationIceTransports` runtime flag 뒤로 옮겼습니다.
+3. 해당 flag는 기본 off 상태라 `iceTransports`가 무시되고, 사이트 호환성 문제가 생기면 Finch 또는 `--enable-features=RTCConfigurationIceTransports`로 기존 동작을 복구할 수 있게 했습니다.
+4. 더 이상 실패 expectation이 필요 없어진 WPT expectation 파일을 삭제하고, Blink fast peerconnection 테스트 기대값에서 `iceTransports` 관련 출력을 제거했습니다.
+
+```diff
+-    // TODO(foolip): |iceTransports| is not in the spec.
+-    // https://crbug.com/659131
+-    RTCIceTransportPolicy iceTransports;
++    [RuntimeEnabled=RTCConfigurationIceTransports] RTCIceTransportPolicy iceTransports;
+```
+
+```diff
++      // Non-standard RTCConfiguration.iceTransports alias. Off by default
++      // (alias removed). Enable via Finch to restore if sites break.
++      // https://crbug.com/488071544
++      name: "RTCConfigurationIceTransports",
+```
+
+## 테스트 방법
+
+Gerrit의 CQ를 통해 변경이 검증된 뒤 머지되었습니다.
+
+- `third_party/blink/web_tests/external/wpt/webrtc/RTCConfiguration-iceTransportPolicy_interop-2026-expected.txt` 삭제
+- `third_party/blink/web_tests/fast/peerconnection/RTCPeerConnection.html` 및 expected output 갱신
+- CQ full run 통과 후 `refs/heads/main@{#1683862}`로 submit
+
+
+## 배운 점
+
+- WebIDL dictionary에서 비표준 멤버를 제거하면, 표준 동작상 알 수 없는 멤버는 무시되어야 합니다.
+- 사용률이 약 `0.00002%`처럼 매우 낮아도 웹 호환성 위험은 남을 수 있으므로, 리뷰에서는 Finch로 되돌릴 수 있는 runtime flag를 요구했습니다.
+- 첫 패치셋에서는 단순 제거였지만, 리뷰 코멘트를 반영해 `RTCConfigurationIceTransports` flag를 추가한 패치셋 2가 LGTM을 받았습니다.
+
+## 참고 자료
+
+- [Gerrit CL 8260551](https://chromium-review.googlesource.com/c/chromium/src/+/8260551)
+- [관련 버그 488071544](https://issues.chromium.org/issues/488071544)
+- [Chromestatus usage metric 1664](https://chromestatus.com/metrics/feature/timeline/popularity/1664)


### PR DESCRIPTION
## Summary

[WPT] webrtc 쪽 RTCConfiguration 내 iceTransports 가 표준에 적합하지 않아 비활성화 하는 작업

- patch1 : 구표준 iceTransports 삭제 -> site break 우려 (구글 내 삭제 기준 시점이 존재하는듯)
- patch2 : flag 처리를 통해 default off 한 뒤, 문제 생기면 fallback 돌릴 수 있도록 처리

## 관련 이슈

- #289 
- [gerrit](https://chromium-review.googlesource.com/c/chromium/src/+/8260551)
