### PR TITLE
contributions: Add 8264335

### DIFF
--- a/data/contributions/8255452.md
+++ b/data/contributions/8255452.md
@@ -1,0 +1,104 @@
+---
+title: "Migrate crypto/sha2 to crypto/hash in webui/certificate_manager"
+date: 2026-08-13
+author: jsy8315
+contribution_url: https://crrev.com/c/8255452
+labels: ["crypto", "refactor"]
+status: merged
+---
+
+`//crypto` 의 신규 API 마이그레이션 작업의 일부로, `chrome/browser/ui/webui/certificate_manager` 디렉터리에서 사용하던 구 API `crypto/sha2.h` 를 신 API `crypto/hash.h` 로 교체했습니다.
+
+## 문제 설명
+
+Chromium 은 `//crypto` 의 API 를 기능별 하위 네임스페이스로 재정리하는 작업을 진행 중이며, SHA-256 해시 API 도 그 대상입니다.
+
+```cpp
+// 구 API — crypto/sha2.h
+namespace crypto {
+  static const size_t kSHA256Length = 32;
+  CRYPTO_EXPORT std::array<uint8_t, kSHA256Length> SHA256Hash(base::span<const uint8_t> input);
+}
+
+// 신 API — crypto/hash.h
+namespace crypto::hash {
+  inline constexpr size_t kSha256Size = 32;
+  CRYPTO_EXPORT std::array<uint8_t, kSha256Size> Sha256(base::span<const uint8_t> data);
+}
+```
+
+- `crypto/sha2.h` 를 include 하는 파일이 저장소 전체에 175개 존재
+- 그중 `chrome/browser/ui/webui/certificate_manager` 에 5개 파일이 해당
+- 신 API 는 `crypto::hash` 라는 하위 네임스페이스로 분리되어 있어, include 경로와 호출부를 함께 수정해야 함
+
+## 해결 내용
+
+### 1. 작업 범위 선정
+
+하나의 CL 은 리뷰어 한 명에게 전부 승인받을 수 있는 범위여야 하므로, OWNERS 가 공통인 디렉터리 단위로 묶었습니다.
+
+```
+chrome/browser/ui/webui/certificate_manager/OWNERS
+  └─ file://net/cert/OWNERS  →  davidben@chromium.org, mattm@chromium.org
+```
+
+5개 파일이 모두 한 디렉터리에 있어 리뷰어 한 명의 승인으로 처리 가능한 구성입니다.
+
+### 2. API 교체
+
+| 기존 | 변경 |
+|---|---|
+| `crypto/sha2.h` | `crypto/hash.h` |
+| `crypto::SHA256Hash(x)` | `crypto::hash::Sha256(x)` |
+| `crypto::kSHA256Length` | `crypto::hash::kSha256Size` |
+
+반환 타입이 양쪽 모두 `std::array<uint8_t, 32>` 로 동일하여 호출부의 타입 변경 없이 교체할 수 있었습니다.
+
+```cpp
+// 변경 전
+std::array<uint8_t, crypto::kSHA256Length> hash;
+if (hash == crypto::SHA256Hash(cert)) {
+
+// 변경 후
+std::array<uint8_t, crypto::hash::kSha256Size> hash;
+if (hash == crypto::hash::Sha256(cert)) {
+```
+
+### 3. 미사용 include 제거
+
+`client_cert_sources.cc` 는 `crypto/sha2.h` 를 include 하고 있었으나 `crypto::` API 를 전혀 사용하지 않아 include 만 제거했습니다.
+
+파일 안에 `sha256_hex_hash` 변수명과 `net::SHA256HashValue` 타입이 있어 사용 중인 것처럼 보이지만, 이들은 `net` 네임스페이스의 별개 타입입니다.
+
+최종 변경 규모는 5개 파일, 14줄 추가 15줄 삭제입니다.
+
+## 테스트 방법
+
+```bash
+autoninja -C out/Default chrome
+autoninja -C out/Default unit_tests
+```
+
+- 수정한 4개 파일이 `CXX` 단계에서 정상 컴파일되는 것을 확인했습니다.
+- `git cl format` 실행 시 변경 사항이 없어 스타일 규약을 준수함을 확인했습니다.
+- 구 API 잔존 여부를 확인했습니다.
+
+  ```bash
+  grep -rn 'crypto/sha2\|crypto::SHA256Hash\|crypto::kSHA256Length' \
+    chrome/browser/ui/webui/certificate_manager/
+  ```
+
+`client_cert_sources_writable_unittest.cc` 는 `BUILD.gn` 에서 `use_nss_certs`(Linux/ChromeOS) 조건부로 빌드되어 macOS 로컬에서는 컴파일 대상이 아니었습니다. 이 부분은 CQ dry run 에서 Linux 봇을 통해 검증했습니다.
+
+## 배운 점
+
+- **OWNERS 는 위치가 아니라 전문성 기준으로 정해집니다.** `certificate_manager` 의 OWNERS 가 `file://net/cert/OWNERS` 를 가리키는 것은 인증서를 다루는 UI 라 인증서 도메인 지식이 필요하기 때문입니다. `file://` 는 부모 디렉터리를 뜻하는 것이 아니라 다른 파일의 명단을 참조하는 링크입니다.
+- **부모 디렉터리의 OWNERS 도 함께 적용되어 승인 가능한 사람이 합집합이 됩니다.** 이번 CL 은 `chrome/browser/ui/OWNERS` 에 등재된 리뷰어의 승인으로 요건이 충족되었습니다.
+- **`BUILD.gn` 의 조건부 빌드를 확인해야 합니다.** 파일이 존재한다고 해서 현재 플랫폼에서 컴파일되는 것은 아니며, `gn args out/Default --list=<플래그>` 로 확인할 수 있습니다.
+- **`git cl presubmit` 과 `git cl upload` 의 검사 세트가 다릅니다.** 같은 항목이 전자에서는 ERROR, 후자에서는 Warning 으로 분류되는 경우가 있습니다.
+
+## 참고 자료
+
+- [//crypto: migrate callers to new APIs](https://issues.chromium.org/issues/372283556)
+- [crypto/hash.h](https://source.chromium.org/chromium/chromium/src/+/main:crypto/hash.h)
+- [chrome/browser/ui/webui/certificate_manager](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/webui/certificate_manager/)

--- a/data/contributions/8264335.md
+++ b/data/contributions/8264335.md
@@ -1,0 +1,120 @@
+---
+title: "Remove @ts-expect-error in BackgroundServiceModel"
+date: 2026-08-15
+author: jsy8315
+contribution_url: https://crrev.com/c/8264335
+labels: ["devtools", "refactor"]
+status: merged
+---
+
+Chrome DevTools 의 JSDoc → TypeScript 마이그레이션 과정에서 억제해둔 타입 오류를 실제로 해결했습니다. `front_end/panels/application/BackgroundServiceModel.ts` 의 `@ts-expect-error` 를 제거하고 `Platform.assertNotNullOrUndefined` 로 코드의 전제를 명시했습니다.
+
+## 문제 설명
+
+DevTools 프론트엔드는 과거 JSDoc 주석으로 타입을 달던 JavaScript 코드베이스였고, TypeScript 로 전환하는 과정에서 **당장 해결하기 어려운 타입 오류를 억제문으로 덮어두고** 넘어갔습니다. 그 흔적이 지금도 남아 있습니다.
+
+```ts
+// TODO(crbug.com/1172300) Ignored during the jsdoc to ts migration)
+// @ts-expect-error
+this.events.get(backgroundServiceEvent.service).push(backgroundServiceEvent);
+```
+
+`Map.prototype.get()` 의 반환 타입은 `V | undefined` 이므로 곧바로 `.push()` 를 호출하면 타입 오류가 발생합니다. 억제문으로 컴파일은 통과시켰지만, **키가 없을 때 런타임에 `TypeError` 가 발생한다는 사실은 그대로 남아 있고 코드에서는 보이지 않게 되었습니다.**
+
+추적 이슈 기준으로 이런 잔재가 65건 남아 있습니다.
+
+```
+no-explicit-any     32
+@ts-expect-error    25
+naming-convention    6
+```
+
+관련 CL 이 2024년 2월 이후 올라오지 않아 2년 반가량 정체된 영역이었습니다.
+
+> 추적 이슈 번호는 Monorail 에서 issues.chromium.org 로 이관되며 재발급되었습니다. 소스 주석은 옛 번호(`crbug.com/1172300`)를 그대로 쓰고 있지만, 커밋 메시지의 `Bug:` 에는 새 번호 `40166562` 를 적어야 합니다.
+
+## 해결 내용
+
+### 1. 대상 선정
+
+한 파일에 억제문이 여러 개 있거나 타입을 고치면 호출부까지 파급되는 건은 제외하고, **근거가 코드로 증명되는 한 건**을 골랐습니다.
+
+| 후보 | 판단 |
+|---|---|
+| `panels/application/IndexedDBModel.ts` | getter 의 선언 타입과 실제 반환 타입이 달라 호출부까지 파급 |
+| `models/persistence/IsolatedFileSystem.ts` | 실제 잠재 버그이나 동작 변경이 필요해 합의가 선행되어야 함 |
+| `panels/media/TickingFlameChart.ts` | 생성자 시그니처 불일치 |
+| `panels/profiler/HeapProfileView.ts` | 한 파일에 5건 |
+| **`panels/application/BackgroundServiceModel.ts`** | **한 건이고 전제를 같은 파일에서 확인 가능** |
+
+### 2. 수정 내용
+
+```diff
++import * as Platform from '../../core/platform/platform.js';
+ import * as SDK from '../../core/sdk/sdk.js';
+```
+
+```diff
+   backgroundServiceEventReceived({backgroundServiceEvent}:
+                                      Protocol.BackgroundService.BackgroundServiceEventReceivedEvent): void {
+-    // TODO(crbug.com/1172300) Ignored during the jsdoc to ts migration)
+-    // @ts-expect-error
+-    this.events.get(backgroundServiceEvent.service).push(backgroundServiceEvent);
++    const events = this.events.get(backgroundServiceEvent.service);
++    Platform.assertNotNullOrUndefined(events);
++    events.push(backgroundServiceEvent);
+     this.dispatchEventToListeners(Events.BackgroundServiceEventReceived, backgroundServiceEvent);
+   }
+```
+
+`assertNotNullOrUndefined` 는 `asserts val is NonNullable<T>` 시그니처를 가지므로, 이 호출을 통과한 뒤에는 컴파일러가 `events` 의 타입을 좁혀 인식합니다. 별도 캐스팅이 필요하지 않습니다.
+
+변경 규모는 AUTHORS 한 줄을 포함해 2개 파일, 5줄 추가 3줄 삭제입니다.
+
+### 3. 왜 옵셔널 체이닝이 아니라 assert 인가
+
+억제문을 지울 때 **무엇으로 대체하느냐가 이 CL 의 실질적인 판단**이었습니다.
+
+| 방법 | 전제가 깨졌을 때 |
+|---|---|
+| `get(s)?.push(e)` | 조용히 무시 → **버그를 숨김** |
+| `?? []` 후 `set()` | 정상처럼 처리 |
+| **`assertNotNullOrUndefined`** | **명확한 메시지와 함께 예외** |
+
+기존 동작이 이미 `TypeError` 였으므로 **assert 는 런타임 동작을 바꾸지 않고 오류 메시지만 명확하게 합니다.** 반면 옵셔널 체이닝은 "절대 `undefined` 면 안 되는 값"에 쓰면 프로토콜 계약 위반을 조용히 삼켜 원인 파악을 어렵게 만듭니다.
+
+키가 항상 존재한다는 근거는 같은 파일에서 확인할 수 있었습니다.
+
+- `enable()` 이 `this.events.set(...)` 을 먼저 호출하고 그 뒤에 `startObserving()` 을 호출합니다. 이벤트가 도착하는 시점에는 항상 키가 존재합니다.
+- 이 맵에서 키를 삭제하는 코드가 없습니다.
+
+`assertNotNullOrUndefined` 는 DevTools 프로덕션 코드 여러 곳에서 쓰이는 관례이며, `ui/legacy/Treeoutline.ts` 가 같은 형태로 사용합니다.
+
+## 테스트 방법
+
+```bash
+npm run build
+npm run lint -- --lint-only front_end/panels/application/BackgroundServiceModel.ts
+```
+
+- DevTools 는 `autoninja` 가 아니라 npm 스크립트로 빌드합니다. `npm run build` 가 타입 검사를 포함하므로, 억제문을 제거한 뒤에도 타입 오류가 없음을 확인했습니다.
+- `npm run lint` 는 로컬 기본값이 **자동 수정 ON** 이라 파일을 조용히 고치고 통과할 수 있습니다. 봇과 같은 조건(캐시 OFF, 자동 수정 OFF)으로 검증하려면 `--lint-only` 를 붙여야 하고, 실행 후 `git status` 로 파일이 변경되지 않았는지 확인해야 합니다.
+- 패치셋 2에서 CQ dry run 을 통과했습니다.
+- 런타임 동작 변화는 없습니다. 전제가 지켜지는 정상 경로에서는 동일하게 동작하고, 위반 시에만 오류 메시지가 명확해집니다.
+
+## 배운 점
+
+- **CQ 실패 요약문은 원인이 아니라 실패한 스텝의 이름입니다.** 이 CL 의 dry run 이 `Failure in Lint Check` 로 실패했지만, 빌드 로그를 7단계 내려가 보니 실제 원인은 봇에서 `third_party/depot_tools/vpython3` 를 찾지 못한 것이었고 ESLint 는 시작조차 하지 못한 상태였습니다. **같은 봇의 다른 CL 두 건이 동일한 지점에서 실패한 것**이 인프라 문제라는 결정적 근거가 되었습니다. 내 코드가 남의 CL 빌드를 깨뜨릴 방법은 없기 때문입니다. 이 근거를 코멘트로 정리해 남기자 리뷰어가 바로 상황을 확인해 주었습니다.
+
+- **외부 기여자는 `Code-Review+1` 이 두 개 필요합니다.** Gerrit 의 제출 조건식이 커미터에게는 한 개, 그 외에는 두 개를 요구합니다. 최근 머지된 외부 기여자 CL 을 확인해 보면 대부분 처음부터 리뷰어를 2~3명 지정합니다. 한 명만 넣고 기다리면 정체됩니다.
+
+- **리뷰어가 배정을 다른 사람에게 넘기면 그 판단을 존중해야 합니다.** 처음 지정한 리뷰어가 스스로를 제거하고 다른 담당자를 넣었는데, 이를 원래대로 되돌렸다가 반나절 넘게 리뷰가 진행되지 않았습니다. 넘긴 쪽에서는 이미 처리를 마친 CL 이라 다시 볼 이유가 없었던 것입니다. 리뷰어가 바뀌었을 때는 **누가 바꿨는지**를 먼저 확인해야 합니다.
+
+- **`git config diff.ignoreSubmodules all` 이 필요합니다.** `build` 와 `third_party/depot_tools` 는 실제 git 서브모듈인데 gclient 가 기록된 리비전보다 새 커밋으로 체크아웃해 두어 항상 diff 가 남고, presubmit 의 `CheckNoUncheckedFiles` 가 이를 잡아 업로드를 막습니다. `git checkout -- build` 로는 인덱스만 되돌아가 즉시 재발하므로 설정을 바꿔야 합니다. 기본값은 depot_tools 가 넣어둔 `dirty` 이며, 커밋 포인터 차이까지 무시하려면 `all` 이 필요합니다.
+
+## 참고 자료
+
+- [jsdoc → ts 마이그레이션 잔재 정리 (Bug 40166562)](https://issues.chromium.org/issues/40166562)
+- [BackgroundServiceModel.ts](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/front_end/panels/application/BackgroundServiceModel.ts)
+- [core/platform/platform.ts — assertNotNullOrUndefined](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/front_end/core/platform/platform.ts)
+- [DevTools contributing 문서](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md)


### PR DESCRIPTION
## Summary

DevTools 의 jsdoc → TypeScript 마이그레이션 과정에서 억제해둔 `@ts-expect-error` 를 제거한 CL([crrev.com/c/8264335](https://crrev.com/c/8264335))이 머지되어 기여 기록을 추가합니다.

`front_end/panels/application/BackgroundServiceModel.ts` 에서 `Map.get()` 의 결과를 그대로 사용하던 부분을 `Platform.assertNotNullOrUndefined` 로 전제를 명시하도록 바꿨습니다. (2 files, +5 -3)

## 관련 GitHub 이슈 번호 : #323

