### PR TITLE
docs: Add license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OSSCA Chromium contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ https://ossca-chromium.github.io/contributions/
 ## CONTRIBUTION GUIDE
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## LICENSE
+
+- 사이트 코드(`src/`, `scripts/` 등): [MIT](LICENSE)
+- Chromium 문서 번역본(`data/docs/`): 원저작물(Copyright The Chromium Authors)을 따라 [BSD-3-Clause](data/docs/LICENSE)
+- 기타 콘텐츠(`data/contributions/`, `data/meetings/`, `data/guide/`): [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/deed.ko)

--- a/data/docs/LICENSE
+++ b/data/docs/LICENSE
@@ -1,0 +1,37 @@
+이 디렉터리(data/docs/)의 문서는 Chromium 프로젝트 문서
+(https://chromium.googlesource.com/chromium/src/)의 한국어 번역본으로,
+원저작물의 BSD-3-Clause 라이선스를 따릅니다.
+
+The documents in this directory are Korean translations of Chromium project
+documentation and are distributed under the original BSD-3-Clause license
+reproduced below.
+
+--------------------------------------------------------------------------
+
+Copyright 2015 The Chromium Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary

저장소에 라이선스를 명시한다. 사이트 코드는 MIT, Chromium 문서 번역본은 BSD-3-Clause, 기타 콘텐츠는 CC BY 4.0.

- **루트 `LICENSE`**: 사이트 코드(`src/`, `scripts/` 등)에 MIT 적용
- **`data/docs/LICENSE`**: Chromium 문서 한국어 번역본에 원저작물 BSD-3-Clause 고지 (Copyright The Chromium Authors)
- **README**: 파트별 라이선스 안내 섹션 추가 (기타 콘텐츠는 CC BY 4.0)

## Background

- **계기**: AI 에이전트 회사들의 오픈소스 지원 프로그램(Claude for Open Source 등) 지원을 검토하던 중, 저장소에 라이선스가 없다는 점 확인
- **문제**: 라이선스 없는 저장소는 엄밀히는 오픈소스가 아니어서 이런 심사에 불리
- **번역본 처리**: `data/docs/`의 Chromium 문서 한국어 번역본은 2차 저작물이므로, 원저작물 라이선스인 BSD-3-Clause를 그대로 유지해야 함

## Changes

| 대상 | 라이선스 | 파일 |
| --- | --- | --- |
| 사이트 코드 (`src/`, `scripts/` 등) | MIT | `LICENSE` (신규) |
| Chromium 문서 번역본 (`data/docs/`) | BSD-3-Clause | `data/docs/LICENSE` (신규) |
| 기타 콘텐츠 (`data/contributions/`, `data/meetings/`, `data/guide/`) | CC BY 4.0 | `README.md`에 안내 |

> `data/contributions/` 등은 여러 멘티가 PR로 기여한 저작물이라, 이 PR이 라이선스 소급 적용의 공지·동의 창구를 겸한다. 기여하신 분들은 리뷰로 확인 부탁드립니다.

## Test

- [x] 코드 변경 없음 — CI 항목(npm test / lint / validate:data / lint:md / build)에 영향 없음

## 관련 이슈

없음
