### PR TITLE
contributions: Add 8256712

### DIFF
--- a/data/contributions/8256712.md
+++ b/data/contributions/8256712.md
@@ -1,0 +1,21 @@
+---
+title: "Use C++20 ends_with in base/debug"
+date: 2026-08-16
+author: iknoom
+contribution_url: https://crrev.com/c/8256712
+labels: ["base", "debug", "refactor"]
+status: merged
+---
+
+`base/debug`의 경로 접미사 검사에 C++20 `std::string::ends_with()`를 적용했습니다.
+
+## 문제 설명
+
+Android stack trace 구현은 APK 경로인지 확인하기 위해 별도의 `EndsWith()` helper를 정의해 사용하고 있었습니다. POSIX stack trace 구현은 삭제된 메모리 매핑 파일 경로를 판별할 때 `base::EndsWith()`와 대소문자 비교 옵션을 사용했습니다.
+
+Chromium C++ 스타일 가이드는 `std::string::(starts,ends)_with`를 허용 기능으로 분류하고, 기존 구현의 전환은 [migration bug 1414647](https://crbug.com/1414647)로 추적합니다.
+
+## 해결 내용
+
+- migration bug 1414647의 전환 방향에 맞춰, `EndsWith()` helper 및 `base::EndsWith()`을 C++20 `std::string::ends_with()`로 변경했습니다.
+


### PR DESCRIPTION
## Summary

`base/debug`의 경로 접미사 검사에 C++20 `std::string::ends_with()`를 적용했습니다.

[Chromium C++ 스타일 가이드](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md)는 `std::string::(starts,ends)_with`를 허용 기능으로 분류하고, 기존 구현의 전환은 [migration bug 1414647](https://crbug.com/1414647)로 추적합니다.

## 관련 이슈

없음