### PR TITLE
contributions: Add 8259828

### DIFF
--- a/data/contributions/8259828.md
+++ b/data/contributions/8259828.md
@@ -1,0 +1,15 @@
+---
+title: "Use span::copy_from() for TaskTrace address copying"
+date: 2026-08-16
+author: iknoom
+contribution_url: https://crrev.com/c/8259828
+labels: ["base", "refactor"]
+status: merged
+---
+
+`TaskTrace::GetAddresses()`의 주소 복사 로직을 `span::copy_from()`으로 정리하였습니다.
+
+## 해결 내용
+
+`base/debug/task_trace.cc`의 `TaskTrace::GetAddresses()`의 주소 복사 로직에서 `std::ranges::copy_n()` 호출을 제거하고 `span::copy_from()`으로 수정했습니다. `static_cast<ptrdiff_t>`을 제거하기 위한 리팩토링입니다.
+


### PR DESCRIPTION
## Summary

`base/debug/task_trace.cc`의 `TaskTrace::GetAddresses()`의 주소 복사 로직에서 `std::ranges::copy_n()` 호출을 제거하고 `span::copy_from()`으로 수정했습니다. `static_cast<ptrdiff_t>`을 제거하기 위한 리팩토링입니다.

## 관련 이슈

없음
