### PR TITLE
fix: Replace draft contribution status with abandoned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Routing quirks: `/contributions` and `/guide` are Redirect stubs; the real lists
 
 ## Data conventions
 
-Contribution frontmatter (see `data/contributions/template.md`): `title`, `date` (YYYY-MM-DD), `author` (GitHub username), `contribution_url`, `labels` (array), `status` (`in review` | `merged` | `draft`). Copy `template.md` to `{ChromiumReviewId}.md`.
+Contribution frontmatter (see `data/contributions/template.md`): `title`, `date` (YYYY-MM-DD), `author` (GitHub username), `contribution_url`, `labels` (array), `status` (`in review` | `merged` | `abandoned`). Copy `template.md` to `{ChromiumReviewId}.md`.
 
 - `npm run validate:data` gates frontmatter in CI. A malformed `date` (e.g. a typo like `2025-05-D8`) parses to `NaN` and silently breaks date sorting — keep dates valid `YYYY-MM-DD`.
 - `gray-matter` may hand back `date` as a `Date` object, so normalize with `new Date(c.date)` before comparing.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,7 +4,7 @@
 
 Google I/O's marketing design is confident but clean. Pages sit on a white canvas (`{colors.background}`) with deep Google-grey ink (`{colors.on-surface}` — #202124), and colour arrives through the four-colour Google chord — blue, green, yellow, red — used as accents, chart hues, and gradient washes, never as heavy colour fields. The signature atmospheric move is a soft pastel mesh of the four brand colours behind the hero, and a Chromium-blue gradient (`#1767d1 → #679ef5`, from the official Chromium logo blues) on marquee text.
 
-The brand anchor is **Google Blue** (`{colors.primary}` — #1a73e8 for actions, #4285f4 in charts/gradients). It owns every CTA, active filter, link… the other three colours support: green for success/merged, yellow for drafts/warnings, red strictly for deadlines/errors. Dark mode mirrors Google's dark theme: near-black grey surfaces (#202124 / #292a2d) with the softened accent set (#8ab4f8, #81c995, #fdd663, #f28b82).
+The brand anchor is **Google Blue** (`{colors.primary}` — #1a73e8 for actions, #4285f4 in charts/gradients). It owns every CTA, active filter, link… the other three colours support: green for success/merged, yellow for abandoned contributions/warnings, red strictly for deadlines/errors. Dark mode mirrors Google's dark theme: near-black grey surfaces (#202124 / #292a2d) with the softened accent set (#8ab4f8, #81c995, #fdd663, #f28b82).
 
 Geometry is friendly and pill-first: buttons and chips are fully rounded (`{rounded.pill}`), cards round at 16–32px, and the hero panel bows out at 32px+. Type is Google Sans in spirit — headlines in a geometric grotesque at 500–700, **sentence case, never all-caps** — over a quiet grotesque body face.
 
@@ -26,7 +26,7 @@ Geometry is friendly and pill-first: buttons and chips are fully rounded (`{roun
 - **Google Blue (action)** (`{colors.primary}` — light #1a73e8 / dark #8ab4f8): every CTA, active filter, link, focus ring.
 - **Chart Blue** (`{chart.bar}` — #4285f4 light / #8ab4f8 dark): charts and gradients.
 - **Green** (`{colors.success}` — light #188038 text · #34a853 fills / dark #81c995): merged status, success stats.
-- **Yellow** (`{colors.warning}` — light #f9ab00 / dark #fdd663): draft status, caution badges — always with dark ink text.
+- **Yellow** (`{colors.warning}` — light #f9ab00 / dark #fdd663): abandoned status, caution badges — always with dark ink text.
 - **Red** (`{colors.error}` — light #d93025 / dark #f28b82): deadlines only. Never decorative.
 
 ### Surface
@@ -114,7 +114,7 @@ Depth comes from borders and subtle tint changes — Google I/O barely uses shad
 ### Chips & Badges
 
 - **`filter-chip`** — pill; active = blue fill + on-primary text, inactive = `{colors.surface-variant}` + muted ink.
-- **`status-badge`** — pill, caption type: merged = green fill (+white/dark-ink per mode), in review = blue fill, draft = yellow fill + dark ink.
+- **`status-badge`** — pill, caption type: merged = green fill (+white/dark-ink per mode), in review = blue fill, abandoned = yellow fill + dark ink.
 - **`label-chip`** — `{colors.primary-container}` fill + blue text.
 
 ### Cards & Containers

--- a/__tests__/lib/contributions.test.ts
+++ b/__tests__/lib/contributions.test.ts
@@ -60,6 +60,25 @@ describe('contributions 유틸리티', () => {
   });
   
   describe('getAllContributions', () => {
+    it.each([
+      ['abandoned', 'abandoned'],
+      ['draft', undefined],
+    ])('%s 상태를 목록과 상세에서 %s로 읽는다', async (status, expected) => {
+      (fs.readdirSync as jest.Mock).mockReturnValue(['123.md']);
+      (fs.readFileSync as jest.Mock).mockReturnValue(`---
+title: Fix docs
+date: 2026-09-05
+author: octocat
+contribution_url: https://crrev.com/c/123
+labels: [docs]
+status: ${status}
+---
+Contribution content`);
+
+      expect(getAllContributions()[0].status).toBe(expected);
+      expect((await getContributionBySlug('123'))?.status).toBe(expected);
+    });
+
     it('모든 컨트리뷰션을 가져옵니다', () => {
       // 가상의 파일 목록 생성
       (fs.readdirSync as jest.Mock).mockReturnValue(['test1.md', 'test2.md', 'not-a-markdown.txt']);
@@ -166,4 +185,4 @@ contribution_url: https://example.com
       expect(isValidGithubUsername('')).toBe(false);
     });
   });
-}); 
+});

--- a/__tests__/scripts/validate-contributions.test.ts
+++ b/__tests__/scripts/validate-contributions.test.ts
@@ -25,6 +25,15 @@ test('잘못된 status를 잡는다', () => {
   expect(errs.some((e) => e.includes('status'))).toBe(true);
 });
 
+test.each(['in review', 'merged', 'abandoned'])('%s 상태를 허용한다', (status) => {
+  expect(validateFrontmatter({ ...valid, status })).toEqual([]);
+});
+
+test('draft 상태를 거부한다', () => {
+  const errs = validateFrontmatter({ ...valid, status: 'draft' });
+  expect(errs.some((e) => e.includes('status'))).toBe(true);
+});
+
 test('잘못된 date 형식을 잡는다', () => {
   const errs = validateFrontmatter({ ...valid, date: '2025/05/08' });
   expect(errs.some((e) => e.includes('date'))).toBe(true);

--- a/data/contributions/template.md
+++ b/data/contributions/template.md
@@ -4,7 +4,7 @@ date: YYYY-MM-DD
 author: GitHubId # github.com/GitHubId
 contribution_url: https://crrev.com/c/XXXXX # Add XXXXX from https://chromium-review.googlesource.com/c/chromium/src/+/XXXXX
 labels: ["label1", "label2"] # directory name and detail
-status: in review # in review, merged 중 하나 선택
+status: in review # in review, merged, abandoned 중 하나 선택
 ---
 
 간략한 소개 문장을 작성하세요. 이 컨트리뷰션이 무엇에 관한 것인지 설명합니다.
@@ -20,6 +20,8 @@ status: in review # in review, merged 중 하나 선택
 ## 해결 내용
 
 어떻게 문제를 해결했는지 설명하세요.
+
+abandoned 상태라면 시도한 접근 방법과 변경을 중단한 이유를 작성하세요.
 
 1. 첫 번째 접근 방법
 2. 구현 세부 사항

--- a/data/docs/contribution-record.md
+++ b/data/docs/contribution-record.md
@@ -43,8 +43,9 @@ cp data/contributions/template.md data/contributions/6520751.md
 | `author`           | 본인 GitHub ID                         | `amoseui`                   |
 | `contribution_url` | `https://crrev.com/c/{ChromiumReviewId}` | `https://crrev.com/c/6520751` |
 | `labels`           | 수정한 디렉터리 + 작업 성격            | `["docs", "fix"]`           |
-| `status`           | `in review` 또는 `merged`              | `in review`                 |
+| `status`           | `in review`, `merged`, `abandoned`              | `in review`                 |
 
+- CL을 중단했다면 `status: abandoned`로 기록하고 본문에 시도한 접근과 중단 이유를 적으세요.
 - `date`는 반드시 유효한 `YYYY-MM-DD` 형식이어야 합니다. 잘못된 날짜(예:
   `2025-05-D8`)는 CI에서 걸리고, 통과하더라도 목록 정렬을 조용히 깨뜨립니다.
 - `author`는 기여자 페이지 링크와 아바타에 그대로 사용되므로 정확한 GitHub

--- a/scripts/validate-contributions.js
+++ b/scripts/validate-contributions.js
@@ -3,7 +3,7 @@ const path = require('path');
 const matter = require('gray-matter');
 
 const REQUIRED = ['title', 'date', 'author', 'contribution_url', 'labels', 'status'];
-const STATUSES = ['in review', 'merged', 'draft'];
+const STATUSES = ['in review', 'merged', 'abandoned'];
 
 // YYYY-MM-DD 문자열이 실제로 존재하는 날짜인지 확인(2025-13-40, 2025-02-30 등 배제)
 function isRealDate(str) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,7 @@
   --color-link: #1a73e8;
   --chart-merged: #34a853;
   --chart-in-review: #4285f4;
-  --chart-draft: #fbbc04;
+  --chart-abandoned: #fbbc04;
   --chart-unknown: #9aa0a6;
   --chart-bar: #4285f4;
   --mesh-base: #f8f9fa;
@@ -49,7 +49,7 @@
   --color-link: #8ab4f8;
   --chart-merged: #81c995;
   --chart-in-review: #8ab4f8;
-  --chart-draft: #fdd663;
+  --chart-abandoned: #fdd663;
   --chart-unknown: #9aa0a6;
   --chart-bar: #8ab4f8;
   --mesh-base: #292a2d;
@@ -78,7 +78,7 @@
   --color-link: var(--color-link);
   --color-chart-merged: var(--chart-merged);
   --color-chart-in-review: var(--chart-in-review);
-  --color-chart-draft: var(--chart-draft);
+  --color-chart-abandoned: var(--chart-abandoned);
   --color-chart-unknown: var(--chart-unknown);
   --color-chart-bar: var(--chart-bar);
   --font-display: var(--font-outfit), ui-sans-serif, system-ui, sans-serif;

--- a/src/components/ContributionSearch.tsx
+++ b/src/components/ContributionSearch.tsx
@@ -12,7 +12,7 @@ const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: '전체' },
   { value: 'in review', label: 'In Review' },
   { value: 'merged', label: 'Merged' },
-  { value: 'draft', label: 'Draft' },
+  { value: 'abandoned', label: 'Abandoned' },
 ];
 
 export default function ContributionSearch({ items }: { items: SearchIndexItem[] }) {

--- a/src/components/StatsCharts.tsx
+++ b/src/components/StatsCharts.tsx
@@ -17,14 +17,14 @@ import type { Stats } from '@/lib/types';
 const STATUS_COLORS: Record<string, string> = {
   merged: 'var(--chart-merged)',
   'in review': 'var(--chart-in-review)',
-  draft: 'var(--chart-draft)',
+  abandoned: 'var(--chart-abandoned)',
   unknown: 'var(--chart-unknown)',
 };
 
 const STATUS_LABELS: Record<string, string> = {
   merged: 'Merged',
   'in review': 'In Review',
-  draft: 'Draft',
+  abandoned: 'Abandoned',
   unknown: '기타',
 };
 

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -3,7 +3,7 @@ import type { ContributionStatus } from '@/lib/types';
 const MAP: Record<ContributionStatus, { label: string; cls: string }> = {
   'in review': { label: 'IN REVIEW', cls: 'bg-primary text-on-primary' },
   merged: { label: 'MERGED', cls: 'bg-success text-white dark:text-black' },
-  draft: { label: 'DRAFT', cls: 'bg-warning text-black' },
+  abandoned: { label: 'ABANDONED', cls: 'bg-warning text-black' },
 };
 
 export default function StatusBadge({ status }: { status?: ContributionStatus }) {

--- a/src/lib/contributions.ts
+++ b/src/lib/contributions.ts
@@ -7,7 +7,7 @@ import type { Contribution, ContributionStatus } from '@/lib/types';
 
 const contributionsDirectory = path.join(process.cwd(), 'data/contributions');
 
-const VALID_STATUSES: ContributionStatus[] = ['in review', 'merged', 'draft'];
+const VALID_STATUSES: ContributionStatus[] = ['in review', 'merged', 'abandoned'];
 
 // frontmatter status를 유니언 타입으로 정규화 (유효하지 않으면 undefined)
 function normalizeStatus(value: unknown): ContributionStatus | undefined {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type ContributionStatus = 'in review' | 'merged' | 'draft';
+export type ContributionStatus = 'in review' | 'merged' | 'abandoned';
 
 export interface Contribution {
   slug: string;


### PR DESCRIPTION
## Summary

컨트리뷰션의 `status: abandoned`가 검증을 통과하고 사이트에서도 표시되도록 `draft` 상태를 `abandoned`로 교체합니다. 허용 상태는 `in review`, `merged`, `abandoned`입니다.

타입·데이터 로더·검색 필터·배지·통계 차트를 함께 수정하고, 기존 템플릿과 작성 가이드에 `abandoned` 선택지 및 중단 이유 작성 안내를 추가했습니다.

## 관련 이슈

없음

## 검증

- 전체 테스트 129개 통과 (33개 suite)
- `abandoned` 허용 및 `draft` 거부, 목록·상세 상태 처리 회귀 테스트 추가
- `npm run lint`, `npm run validate:data`, `npm run lint:md`, `npm run build` 통과
- `git diff --check` 통과
