### PR TITLE
contributions: Add 8362029

### DIFF
--- a/data/contributions/8362029.md
+++ b/data/contributions/8362029.md
@@ -1,0 +1,64 @@
+---
+title: "Remove unused SecureHash include from FileSystemAccessManagerImpl"
+date: 2026-09-05
+author: zbnerd
+contribution_url: https://crrev.com/c/8362029
+labels: ["content", "file_system_access", "cleanup"]
+status: merged
+---
+
+Chromium의 File System Access 구현에서 사용하지 않는
+`crypto/secure_hash.h` include를 제거했습니다. 이 변경은 2026년 9월 9일
+Chromium main에 병합되었습니다.
+
+## 문제 설명
+
+`content/browser/file_system_access/file_system_access_manager_impl.cc`에는
+`crypto::SecureHash`를 사용하는 코드가 없는데도
+`crypto/secure_hash.h` include가 남아 있었습니다.
+
+이처럼 사용하지 않는 include는 불필요한 헤더 의존성을 만듭니다.
+이번 CL은 `crypto/secure_hash.h`를 제거하기 위한 정리 작업의 일부로,
+[Chromium Issue 372283556](https://issues.chromium.org/issues/372283556)과
+연결되어 있습니다.
+
+## 해결 내용
+
+`FileSystemAccessManagerImpl` 구현 파일의 include 목록에서 다음 한 줄을
+삭제했습니다.
+
+```diff
+-#include "crypto/secure_hash.h"
+```
+
+최종 패치는 한 파일에서 한 줄을 제거하는 변경입니다.
+
+## 테스트 방법
+
+CL의 커밋 메시지와 Gerrit 실행 기록에 남은 검증은 다음과 같습니다.
+
+1. `git cl presubmit --upload`로 업로드 전 presubmit 검사를 실행했습니다.
+2. 기존 `out/Default`의 빌드 옵션을 재사용한 Clang 구문 검사로 대상 파일을
+   확인했습니다.
+3. 2026년 9월 5일 Patch Set 2의
+   [CQ dry run](https://luci-change-verifier.appspot.com/ui/run/chromium/8834376993854-1-fb8169754cb00c03)이
+   통과했습니다.
+4. 2026년 9월 9일 Patch Set 3의
+   [CQ 실행](https://luci-change-verifier.appspot.com/ui/run/chromium/8834047337854-1-2a351c88fb7a8ac7)을
+   거쳐, 자동 rebase된 Patch Set 4가 main에 병합되었습니다.
+
+## 배운 점
+
+- 오래된 API를 정리할 때는 실제 사용 코드를 이전하는 작업뿐 아니라,
+  사용하지 않는 include를 제거하는 작업도 필요합니다.
+- include를 제거할 때는 해당 파일의 심볼 사용 여부를 확인하고,
+  구문 검사와 CQ로 변경을 검증할 수 있습니다.
+- 기존 빌드 설정을 재사용하면 대상 파일에 맞는 옵션으로 구문 검사를
+  수행할 수 있습니다.
+
+## 참고 자료
+
+- [Chromium Gerrit CL 8362029](https://chromium-review.googlesource.com/c/chromium/src/+/8362029)
+- [최종 Patch Set 4](https://chromium-review.googlesource.com/c/chromium/src/+/8362029/4)
+- [Chromium Issue 372283556](https://issues.chromium.org/issues/372283556)
+- [Chromium main에 반영된 커밋](https://chromium.googlesource.com/chromium/src/+/99fcf5924f9963fa285fba294a0354eaf9d43390)


### PR DESCRIPTION
## Summary

  - template.md 형식으로 CL 8362029 (https://crrev.com/c/8362029)의 기여 기록을 추가했습니다.
  - 미사용 crypto/secure_hash.h include 제거 배경과 검증 결과를 정리하였습니다

  ## 관련 이슈

  - #391 (https://github.com/OSSCA-chromium/contributions/issues/391)
