### PR TITLE
contributions: Add 8343748

### DIFF
--- a/data/contributions/8343748.md
+++ b/data/contributions/8343748.md
@@ -1,0 +1,56 @@
+---
+title: "Fix unsafe buffer usage in GamepadStructTraitsTest"
+date: 2026-09-03
+author: tomatozil
+contribution_url: https://chromium-review.googlesource.com/c/chromium/src/+/8343748
+labels: ["device", "gamepad"]
+status: merged
+---
+
+GamepadStructTraitsTest에서 unsafe buffer 경고를 유발하는 메모리 초기화와 배열 순회 코드를 안전한 C++ 표준 라이브러리 사용 방식으로 변경함.
+
+## 문제 설명
+
+`device/gamepad/public/cpp/gamepad_mojom_traits_unittest.cc`에는 `GamepadVector`, `GamepadQuaternion`, `GamepadPose`, `GamepadTouch`, `Gamepad` 객체를 `memset`으로 0 초기화하는 코드가 있었음. 이 코드는 unsafe buffer 분석을 우회하기 위해 `UNSAFE_TODO`로 감싸져 있었음.
+
+또한 게임패드 ID와 각 배열을 수동 인덱스 루프로 복사하고 비교하고 있어, 버퍼 접근 범위를 직접 관리해야 했음.
+
+## 해결 내용
+
+unsafe한 버퍼 접근을 제거하고 객체와 컨테이너의 의미가 코드에 직접 드러나도록 수정함.
+
+전
+```cpp
+GamepadVector wgv;
+UNSAFE_TODO(memset(&wgv, 0, sizeof(GamepadVector)));
+
+for (size_t i = 0; i < kTestIdStringLength; i++) {
+  send.id[i] = kTestIdString[i];
+}
+```
+후
+```cpp
+GamepadVector wgv = {};
+
+std::ranges::copy(kTestIdString, send.id.begin());
+```
+
+`isWebGamepadEqual`의 수동 배열 비교도 컨테이너 비교와 `std::ranges::equal`로 교체함. 이를 위해 `<algorithm>`을 추가하고 더 이상 필요하지 않은 `base/compiler_specific.h`를 제거함.
+
+## 테스트 방법
+
+
+변경된 `GamepadStructTraitsTest` 관련 단위 테스트를 실행해 기존 직렬화 및 역직렬화 동작이 유지되는지 확인함. 리뷰 과정에서 `send.type == echo.type` 비교 조건을 복원한 뒤 관련 테스트를 다시 실행하고 새 patch set을 업로드함.
+
+Gerrit의 자동화 검사와 Commit Queue 검사를 통과했으며, 2026-09-11에 Chromium main 브랜치에 병합됨.
+
+
+## 배운 점
+
+- `UNSAFE_TODO`로 경고를 숨기는 대신 값 초기화와 표준 알고리즘으로 버퍼 접근 자체를 안전하게 만들 수 있음을 배움.
+- `std::ranges::copy`와 `std::ranges::equal`을 사용하면 배열의 크기와 인덱스를 직접 관리하는 코드를 줄이고 의도를 명확히 표현할 수 있음.
+- AI가 제안한 초기 패치도 리뷰어의 피드백과 회귀 테스트를 통해 동작 조건을 다시 확인해야 함.
+
+## 참고 자료
+
+- [컨트리뷰션 가이드](https://github.com/OSSCA-chromium/contributions/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

GamepadStructTraitsTest에서 unsafe buffer 경고를 유발하는 메모리 초기화와 배열 순회 코드를 안전한 C++ 표준 라이브러리 사용 방식으로 변경함.

## 관련 이슈

#366 