### PR TITLE
contributions: Add 8345888

### DIFF
--- a/data/contributions/8146339.md
+++ b/data/contributions/8146339.md
@@ -1,0 +1,129 @@
+---
+
+title: "Fix BigBuffer link in Mojo style guide"
+
+date: 2026-07-28
+
+author: TinyGeek # github.com/TinyGeek
+
+contribution_url: https://crrev.com/c/8146339
+
+labels: ["docs", "mojo"]
+
+status: merged
+
+--------------
+
+Chromium의 Mojo 스타일 가이드에서 잘못 연결되던 `BigBuffer` 문서 링크를 저장소 루트 기준의 경로로 수정했습니다.
+
+## 문제 설명
+
+`docs/security/mojo.md`의 `BigBuffer` 링크가 다음과 같은 상대 경로로 작성되어 있었습니다.
+
+```markdown
+
+[BigBuffer](mojo/public/mojom/base/big_buffer.mojom)
+
+```
+
+Gitiles는 이 경로를 현재 문서가 위치한 `docs/security` 디렉터리를 기준으로 해석합니다. 따라서 실제로는 다음과 같은 존재하지 않는 경로를 가리키게 됩니다.
+
+```text
+
+docs/security/mojo/public/mojom/base/big_buffer.mojom
+
+```
+
+이로 인해 Mojo 스타일 가이드에서 `BigBuffer` 링크를 클릭하면 실제 소스 파일로 이동할 수 없었습니다.
+
+* 상대 경로가 현재 문서의 디렉터리를 기준으로 해석됨
+
+* 존재하지 않는 경로로 연결되어 링크가 정상적으로 동작하지 않음
+
+* 문서를 읽는 사용자가 `BigBuffer` 정의를 바로 확인할 수 없음
+
+## 해결 내용
+
+링크 경로 앞에 `/`를 추가하여 Gitiles가 Chromium 저장소의 루트 디렉터리를 기준으로 경로를 해석하도록 수정했습니다.
+
+```diff
+
+-[BigBuffer](mojo/public/mojom/base/big_buffer.mojom) uses shared memory to make
+
++[BigBuffer](/mojo/public/mojom/base/big_buffer.mojom) uses shared memory to make
+
+```
+
+변경 후 링크는 저장소 루트의 다음 파일을 올바르게 가리킵니다.
+
+```text
+
+mojo/public/mojom/base/big_buffer.mojom
+
+```
+
+또한 Chromium 첫 기여 과정에서 기여자 정보를 등록하기 위해 `AUTHORS` 파일에 이름과 이메일을 추가했습니다.
+
+주요 변경 파일은 다음과 같습니다.
+
+1. `docs/security/mojo.md`
+
+   * `BigBuffer` 링크를 저장소 루트 기준 경로로 변경
+
+2. `AUTHORS`
+
+   * 기여자 정보 추가
+
+기능 코드에는 영향을 주지 않고, 잘못된 문서 링크만 최소 범위로 수정했습니다.
+
+## 테스트 방법
+
+문서 링크 수정이므로 별도의 단위 테스트나 성능 테스트는 필요하지 않았으며, 다음 방법으로 변경 사항을 검증했습니다.
+
+1. **Gitiles 링크 확인**
+
+   * 수정된 Mojo 스타일 가이드 페이지에서 `BigBuffer` 링크를 클릭
+
+   * `mojo/public/mojom/base/big_buffer.mojom` 파일로 정상 이동하는지 확인
+
+2. **파일 권한 검사**
+
+```bash
+
+python3 tools/checkperms/checkperms.py
+
+```
+
+검사 결과 `SUCCESS`를 확인했습니다.
+
+3. **Chromium Presubmit 검사**
+
+   * `git cl upload` 과정에서 Chromium presubmit 검사를 수행
+
+   * 관련 검사가 정상적으로 통과함을 확인
+
+4. **Gerrit 리뷰 및 CQ 확인**
+
+   * Gerrit 코드 리뷰를 통과
+
+   * Chromium LUCI CQ를 통해 `main` 브랜치에 정상 반영됨
+
+문서 경로만 변경한 작업이므로 Chromium 전체 빌드 및 성능 테스트는 수행하지 않았습니다.
+
+## 배운 점
+
+* Gitiles의 상대 경로는 현재 Markdown 파일이 위치한 디렉터리를 기준으로 해석된다는 점을 배웠습니다.
+
+* 경로 앞에 `/`를 추가하면 저장소 루트 기준의 링크를 작성할 수 있다는 것을 확인했습니다.
+
+* Chromium의 `AUTHORS`, `Change-Id`, Gerrit 리뷰, Presubmit, Commit Queue로 이어지는 기여 절차를 경험했습니다.
+
+* 작은 문서 수정이라도 실제 링크 동작과 변경 범위를 직접 검증하는 과정이 중요하다는 것을 배웠습니다.
+
+* 대규모 오픈소스에서는 문제를 해결하는 것뿐만 아니라, 변경 범위를 최소화하고 리뷰어가 의도를 빠르게 이해할 수 있도록 커밋 메시지를 작성하는 것도 중요하다는 점을 배웠습니다.
+
+## 참고 자료
+
+* [Bug link](https://crbug.com/538651940)
+
+* [CL link](https://crrev.com/c/8146339)

--- a/data/contributions/8146339.md
+++ b/data/contributions/8146339.md
@@ -1,18 +1,11 @@
 ---
-
 title: "Fix BigBuffer link in Mojo style guide"
-
 date: 2026-07-28
-
-author: TinyGeek # github.com/TinyGeek
-
+author: zbnerd # github.com/zbnerd
 contribution_url: https://crrev.com/c/8146339
-
 labels: ["docs", "mojo"]
-
 status: merged
-
---------------
+---
 
 Chromium의 Mojo 스타일 가이드에서 잘못 연결되던 `BigBuffer` 문서 링크를 저장소 루트 기준의 경로로 수정했습니다.
 

--- a/data/contributions/8345888.md
+++ b/data/contributions/8345888.md
@@ -1,0 +1,80 @@
+---
+title: "content: Report inotify modifications before close"
+date: 2026-09-02
+author: zbnerd
+contribution_url: https://crrev.com/c/8345888
+labels: ["content", "file_system_access", "fix"]
+status: merged
+---
+
+Linux의 `FilePathWatcher`가 파일 디스크립터를 닫기 전에도 파일 쓰기를 감지하도록 inotify 이벤트 구독을 수정하고, 열린 파일에 대한 변경 알림을 검증하는 회귀 테스트를 추가했습니다.
+
+## 문제 설명
+
+기존 구현은 쓰기 가능한 파일 디스크립터가 닫힐 때 발생하는 `IN_CLOSE_WRITE`를 구독하고 있었습니다. 따라서 네이티브 프로그램이 파일 디스크립터를 오랫동안 열어 둔 채 `write()`를 호출하면, 실제 파일 내용이 바뀌어도 닫기 전까지 관찰자에게 변경 알림이 전달되지 않았습니다.
+
+- 이벤트 처리 코드에는 `IN_MODIFY`를 수정 이벤트로 분류하는 분기가 있었지만, `inotify_add_watch()`의 구독 마스크에는 해당 이벤트가 빠져 있었습니다.
+- 기존 `ModifiedFile` 단위 테스트는 파일을 쓴 뒤 디스크립터를 닫는 `WriteFile()`을 사용하므로, `IN_CLOSE_WRITE`만 구독해도 통과했습니다.
+- 리뷰에서 확인한 WPT의 writable stream 테스트도 스트림을 닫은 뒤의 변경 알림을 검증하므로, 네이티브 쓰기 이후 디스크립터를 계속 열어 두는 상황을 포착하지 못했습니다.
+
+## 해결 내용
+
+최신 Patch Set 5에서는 다음 두 파일을 수정했습니다.
+
+1. `content/browser/file_system_access/file_path_watcher/file_path_watcher_inotify.cc`
+
+   감시 이벤트를 `IN_CLOSE_WRITE`에서 `IN_MODIFY`로 바꾸어 파일 쓰기 시점에 알림을 받을 수 있도록 했습니다. 수정 이벤트를 분류하는 조건에서도 `IN_CLOSE_WRITE`를 제거하여, 쓰기 후 파일을 닫을 때 추가 수정 알림이 발생하는 것을 방지했습니다.
+
+   ```diff
+   -      IN_CREATE | IN_DELETE | IN_CLOSE_WRITE | IN_MOVE | IN_ONLYDIR);
+   +      IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVE | IN_ONLYDIR);
+
+   -  } else if (event_mask & (IN_MODIFY | IN_CLOSE_WRITE)) {
+   +  } else if (event_mask & IN_MODIFY) {
+   ```
+
+2. `content/browser/file_system_access/file_path_watcher/file_path_watcher_unittest.cc`
+
+   Linux와 ChromeOS에서 실행하는 `FilePathWatcherWithChangeInfoTest.ModifiedFileWhileOpen` 테스트를 추가했습니다. `base::File`로 파일을 열어 쓰고, 파일을 닫기 전에 수정 알림을 기다리도록 구성했습니다. 이를 위해 `base/containers/span.h`와 `base/files/file.h`도 추가했습니다.
+
+리뷰에서는 `IN_MODIFY`와 `IN_CLOSE_WRITE`를 함께 구독하는 방안도 논의했습니다. 작성자의 확인에 따르면 일반적인 쓰기 후 닫기 순서에서 두 번의 수정 알림이 발생할 수 있고, 현재 FSA 관찰 경로에는 이를 일반적으로 제거하는 중복 제거 처리가 없습니다. 최신 패치는 `IN_MODIFY`만 구독하는 형태를 유지합니다.
+
+또한 `IN_CLOSE_WRITE` 제거가 writable `mmap`의 기존 닫기 기반 알림에 영향을 줄 수 있다는 점을 논의했습니다. 작성자는 이를 별도 변경 경로로 구분하여 후속 이슈와 회귀 테스트로 다루겠다고 밝혔으며, 이 CL에서 해결된 범위에는 포함하지 않았습니다.
+
+## 테스트 방법
+
+아래 내용은 Gerrit에 올라온 회귀 테스트와 리뷰·CQ 기록을 기준으로 정리했습니다. 보고서 작성 과정에서 Chromium 빌드나 해당 테스트를 새로 실행한 것은 아닙니다.
+
+1. **파일을 닫기 전 수정 알림 검증**
+
+   `ModifiedFileWhileOpen`은 초기 파일을 생성하고 감시를 등록한 뒤, `base::File`을 쓰기 모드로 열어 내용을 변경합니다. `writer.Close()`보다 먼저 `RunUntilEventsMatch(matcher)`를 호출하여, 열린 디스크립터에 대한 쓰기만으로 수정 알림이 도착하는지 검증합니다.
+
+2. **닫기 시 추가 알림 검증**
+
+   쓰기 알림을 받은 뒤 남아 있는 이벤트를 처리하고 파일을 닫습니다. 이어서 `SpinAndExpectNoEvents()`로 닫기 때문에 추가 알림이 발생하지 않는지 확인합니다. 최신 테스트는 알림 지연 문제뿐 아니라 패치가 선택한 중복 알림 방지 동작도 검증합니다.
+
+3. **리뷰 중 수동 확인**
+
+   작성자는 Linux의 실제 `FilePathWatcher`와 FSA 관찰 경로에서 열린 디스크립터에 대한 쓰기 알림 및 반복 쓰기에 따른 반복 콜백을 확인했다고 보고했습니다. writable `mmap`에 대한 관찰은 기존 회귀 테스트 결과가 아니라 별도의 수동 테스트 결과라고 명시했습니다.
+
+4. **Chromium CQ 결과**
+
+   Gerrit 기록상 Patch Set 5는 2026년 9월 2일과 9월 11일의 CQ dry run을 통과했으며, 9월 12일 UTC에 CQ full run이 시작되었습니다.
+
+## 배운 점
+
+- 이벤트를 처리하는 분기가 존재하더라도, 운영체제에 해당 이벤트를 구독하지 않으면 알림을 받을 수 없습니다. 감시 등록과 이벤트 분류를 함께 확인해야 합니다.
+- 회귀 테스트에서는 파일 쓰기뿐 아니라 파일 디스크립터의 수명도 중요합니다. 자동으로 파일을 닫는 헬퍼만 사용하면 닫기 이전의 알림 누락을 놓칠 수 있습니다.
+- 웹의 writable stream 테스트와 네이티브 파일 쓰기 테스트는 검증하는 경로가 다릅니다. 리뷰에서는 네이티브 쓰기를 수행하는 테스트 API의 필요성도 제기되었고, 관련 후속 이슈가 공유되었습니다.
+- 알림 시점을 앞당길 때는 반복 콜백과 닫기 시 중복 알림도 함께 고려해야 합니다. 디바운싱이나 플랫폼 간 알림 정책까지 바꾸는 작업은 별도 범위로 검토할 필요가 있습니다.
+- CQ dry run 통과와 최종 병합은 별개의 단계이므로, 기여 기록의 상태는 실제 Gerrit 상태에 맞춰 관리해야 합니다.
+
+## 참고 자료
+
+- [Chromium Gerrit CL 8345888 및 리뷰 논의](https://chromium-review.googlesource.com/c/chromium/src/+/8345888)
+- [원인 이슈: 열린 파일 디스크립터의 쓰기 알림 누락](https://crbug.com/343997767)
+- [Patch Set 5: inotify 구현 변경](https://chromium-review.googlesource.com/c/chromium/src/+/8345888/5/content/browser/file_system_access/file_path_watcher/file_path_watcher_inotify.cc)
+- [Patch Set 5: 회귀 테스트 추가](https://chromium-review.googlesource.com/c/chromium/src/+/8345888/5/content/browser/file_system_access/file_path_watcher/file_path_watcher_unittest.cc)
+- [네이티브 쓰기 테스트 API 관련 후속 이슈](https://crbug.com/558992054)
+- [2026년 9월 11일 CQ dry run](https://luci-change-verifier.appspot.com/ui/run/chromium/8833851179854-1-a443a8757eddf026)
+- [2026년 9월 12일 CQ full run](https://luci-change-verifier.appspot.com/ui/run/chromium/8833742963854-1-7960cd802ef44c44)


### PR DESCRIPTION
 ## Summary

  - 문제: Linux FilePathWatcher가 파일을 닫기 전까지 쓰기 변경을 알리지 않았습니다.
  - 해결: IN_CLOSE_WRITE를 IN_MODIFY로 교체하고 회귀 테스트를 추가했습니다.
  - 결과: 파일을 닫기 전에도 변경 알림을 전달하고, 닫기 시 중복 알림을 방지했습니다.

  ## 관련 이슈
#374 