### PR TITLE
contributions: Add 8402737

### DIFF
--- a/data/contributions/8402737.md
+++ b/data/contributions/8402737.md
@@ -1,0 +1,62 @@
+---
+title: "content: Preserve mmap notifications when observing inotify writes"
+date: 2026-09-13
+author: zbnerd
+contribution_url: https://crrev.com/c/8402737
+labels: ["content", "file_system_access", "fix", "test"]
+status: in review
+---
+
+Linux 파일 변경 감시에서 일반 쓰기를 조기에 알리면서 writable mmap 변경에 대한
+최선 노력 알림을 유지하는 패치입니다. 현재 Gerrit WIP 상태입니다.
+
+## 문제 설명
+
+inotify의 `IN_MODIFY`는 일반 쓰기를 파일이 닫히기 전에 알릴 수 있지만,
+`MAP_SHARED` 매핑을 통한 변경에는 발생하지 않습니다.
+`IN_CLOSE_WRITE` 구독을 제거하면 writable 매핑의 마지막 참조가 해제될 때
+받을 수 있던 변경 알림도 사라집니다.
+
+두 이벤트를 함께 구독하면 같은 쓰기에 여러 알림이 발생할 수 있습니다.
+그러나 이전 `IN_MODIFY`를 근거로 이후 close를 무조건 무시하면,
+앞선 알림 뒤에 이루어진 mmap 변경을 놓칠 수 있습니다.
+
+## 해결 내용
+
+- `IN_MODIFY`와 `IN_CLOSE_WRITE`를 함께 구독하고 수정 알림으로 처리합니다.
+- 한 번 읽은 버퍼 안에서 동일 항목의 연속된 수정 이벤트만 합칩니다.
+- 서로 다른 읽기 버퍼 사이에는 중복 제거 상태를 유지하지 않습니다.
+- 이벤트 이름은 길이가 검사된 `base::span`으로 비교합니다.
+- mmap 변경과 이벤트 병합의 회귀 테스트를 추가하고,
+  기존 쓰기 테스트는 새로 수신한 알림의 경로와 오류 여부를 검증하도록 보완합니다.
+
+매핑을 유지하는 동안 모든 변경을 즉시 감지하거나 알림을 정확히 한 번만
+전달하는 보장은 제공하지 않습니다.
+
+## 테스트 방법
+
+- WSL Linux의 tmpfs와 ext4에서 일반 쓰기와 mmap의 inotify 이벤트를 비교했습니다.
+- Chromium 컴파일러와 기존 빌드 의존성을 재사용한 로컬 FilePathWatcher 하네스에서
+  수정한 프로덕션 코드와 테스트를 컴파일하고 링크했습니다.
+- `-Werror=unsafe-buffer-usage-in-libc-call`을 적용한 컴파일에 성공했습니다.
+- 로컬 watcher 테스트 208개가 통과했습니다. mmap 및 버퍼 처리 관련 24개도
+  별도로 실행해 통과했습니다.
+- `clang-format`과 `git diff --check`를 통과했습니다.
+- 패치셋 4의 CI 컴파일에서 발견된 `memcmp` 안전성 오류를 수정하고,
+  패치셋 5에서 Dry Run을 다시 요청했습니다. 원격 CI 검증은 진행 중입니다.
+
+전체 Chrome 빌드와 JavaScript FileSystemObserver 종단간 테스트 결과는 아닙니다.
+
+## 배운 점
+
+수정 시각이나 이전 알림만으로 같은 파일의 변경을 중복이라고 판단하면
+추가 mmap 변경을 누락할 수 있습니다. 커널 이벤트가 제공하는 정보의 한계를
+고려해 중복 제거 범위를 제한해야 합니다.
+
+## 참고 자료
+
+- [Chromium 이슈 559925525](https://crbug.com/559925525)
+- [Gerrit CL 8402737](https://crrev.com/c/8402737)
+- [일반 쓰기의 조기 알림 변경 CL 8345888](https://crrev.com/c/8345888)
+- [Chromium C++ 스타일 가이드](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
+


### PR DESCRIPTION
• ## Summary

  - 문제: Linux에서 IN_MODIFY만 감시하면 mmap을 통한 파일 변경 알림이 누락됩니다.
  - 해결: IN_CLOSE_WRITE를 함께 감시하고, 같은 읽기 버퍼의 연속된 중복 수정 알림을 합쳤습니다.
  - 결과: mmap 변경 알림을 보완했으며, 로컬 watcher 빌드와 테스트 208개가 통과했습니다.

  ## 관련 이슈

#434 